### PR TITLE
chore: migrate Lambda runtime provided.al2 -> provided.al2023

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ custom:
   scripts:
     hooks:
       # sls deploy / sls package 時に bootstrap を静的ビルドする。
-      # macOS / Apple Silicon でも Lambda(provided.al2, x86_64) 互換の
+      # macOS / Apple Silicon でも Lambda(provided.al2023, x86_64) 互換の
       # 静的バイナリを得るため、linux/amd64 を明示して Docker でビルドする。
       # chmod はコンテナ内(root)で実行する。Linux ランナーでは生成物が
       # root 所有になり、コンテナ外の runner ユーザーでは chmod できないため。
@@ -18,7 +18,7 @@ custom:
 
 provider:
   name: aws
-  runtime: provided.al2
+  runtime: provided.al2023
   timeout: 300
   region: ap-northeast-1
   stage: ${opt:stage, self:custom.defaultStage}


### PR DESCRIPTION
Lambda runtime を provided.al2 から provided.al2023 へ移行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)