### PR TITLE
fix: notifications API の断続的な 401 をスキップする

### DIFF
--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -19,6 +19,10 @@ module Github
       if res.status_code >= 500
         Serverless::Lambda.print_log "return 5xx error from notifications api"
         return Array(Notifications).new
+      elsif res.status_code == 401
+        # GitHub が断続的に 401 を返すことがあるため、毎分の次回実行に任せてスキップする
+        Serverless::Lambda.print_log "return 401 error from notifications api, skip"
+        return Array(Notifications).new
       elsif res.status_code >= 400
         Serverless::Lambda.print_log "return 4xx error from notifications api"
         err = Error.from_json res.body

--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -20,7 +20,10 @@ module Github
         Serverless::Lambda.print_log "return 5xx error from notifications api"
         return Array(Notifications).new
       elsif res.status_code == 401
-        # GitHub が断続的に 401 を返すことがあるため、毎分の次回実行に任せてスキップする
+        # GitHub が断続的に 401 を返すことがあるため、毎分の次回実行に任せてスキップする。
+        # トークン失効などの恒久的な 401 までサイレントに握りつぶす点は本来リトライや
+        # 連続失敗の監視で区別すべきだが、個人用途の通知ツールであり実装コストに
+        # 見合わないため割り切る。
         Serverless::Lambda.print_log "return 401 error from notifications api, skip"
         return Array(Notifications).new
       elsif res.status_code >= 400


### PR DESCRIPTION
## 概要

本番環境で GitHub の \`/notifications\` API が断続的に \`401 Requires authentication\` を返し、毎分実行の Lambda がそのたびに例外送出 → アラート通知 → Unhandled エラーになっていた問題の修正です。

## 原因

- トークン自体は有効（手元検証で30回中23回は 200、7回が 401 と間欠的に発生）
- \`find_notifications_unread\` が 4xx を一律致命的エラーとして \`raise\` していたため、一時的な 401 でも本番エラーとして扱われていた

## 対応

- \`/notifications\` のレスポンスが 401 の場合は 5xx と同様に非致命扱いとし、ログを出して空配列を返す（次回の毎分実行に任せる）
- 401 以外の 4xx（404 など本当の不正）は従来どおり \`raise\` する

## 動作確認

- Docker (linux/arm64, crystallang/crystal:latest) で \`crystal build --no-codegen\` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)