### PR TITLE
fix: musl(Alpine)で静的ビルドし外部HTTPS通信を復旧

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -18,11 +18,15 @@ custom:
       # amazonlinux:2023 上で再現確認済み: glibc 静的=失敗 / musl 静的=成功。
       # musl は完全な静的バイナリでも外部通信が動くため Alpine でビルドする。
       #
+      # 完全静的リンクには OpenSSL/zlib/libevent の静的ライブラリ(.a)が必要。
+      # 現行イメージには同梱されているが、将来イメージから外れてもリンクエラー
+      # (cannot find -lssl 等)にならないよう apk add で明示的に導入しておく。
+      #
       # chmod はコンテナ内(root)で実行する。Linux ランナーでは生成物が
       # root 所有になり、コンテナ外の runner ユーザーでは chmod できないため。
       'before:package:createDeploymentArtifacts': |
         docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work crystallang/crystal:latest-alpine \
-          sh -c "crystal build --link-flags -static -o bootstrap src/main.cr && chmod +x bootstrap"
+          sh -c "apk add --no-cache openssl-libs-static zlib-static libevent-static && crystal build --link-flags -static -o bootstrap src/main.cr && chmod +x bootstrap"
 
 provider:
   name: aws

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,10 +10,18 @@ custom:
       # sls deploy / sls package 時に bootstrap を静的ビルドする。
       # macOS / Apple Silicon でも Lambda(provided.al2023, arm64) 互換の
       # 静的バイナリを得るため、linux/arm64 を明示して Docker でビルドする。
+      #
+      # ベースイメージは musl の Alpine(crystallang/crystal:*-alpine) を使う。
+      # glibc を静的リンク(--link-flags -static)したバイナリは provided.al2023
+      # 上で外部 HTTPS が失敗し(OpenSSL の STORE 初期化エラー等)、
+      # api.github.com / hooks.slack.com への通信が一切できず通知を送れなくなる。
+      # amazonlinux:2023 上で再現確認済み: glibc 静的=失敗 / musl 静的=成功。
+      # musl は完全な静的バイナリでも外部通信が動くため Alpine でビルドする。
+      #
       # chmod はコンテナ内(root)で実行する。Linux ランナーでは生成物が
       # root 所有になり、コンテナ外の runner ユーザーでは chmod できないため。
       'before:package:createDeploymentArtifacts': |
-        docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work crystallang/crystal:latest \
+        docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work crystallang/crystal:latest-alpine \
           sh -c "crystal build --link-flags -static -o bootstrap src/main.cr && chmod +x bootstrap"
 
 provider:


### PR DESCRIPTION
## 概要
数日間 Slack への通知が止まっていた原因を調査し修正する。

## 停止のタイムライン（CloudWatch ログで特定）
- 最後の成功（`notifications body` ログ）: **2026-06-15 19:16:02 JST**
- 壊れた成果物のデプロイ（Lambda LastModified）: **2026-06-15 19:20:42 JST**
- 以降、GitHub 取得成功ログは **0 件**（デプロイ直後から完全停止）

ビルド方法の変更自体は 2026-06-01 `ede2902` だが、実際に壊れたバイナリがデプロイされた 06-15 19:20 から停止している。

## 症状
- Slack チャンネルに通知もエラーアラートも一切届かない
- それでいて Lambda は毎分起動している（EventBridge `rate(1 minute)` は ENABLED）

## 根本原因
ビルド方法が **glibc を静的リンク**していたこと（[serverless.yml](../blob/master/serverless.yml) のビルドフック）。

- `ede2902` でコンテナイメージ配布 → **静的バイナリ配布**へ変更された際、ベースイメージ `crystallang/crystal:latest`（glibc）で `crystal build --link-flags -static` していた。
- glibc を静的リンクしたバイナリは `provided.al2023` 上で**外部 HTTPS が失敗**する（OpenSSL の STORE 初期化エラー `unregistered scheme`）。
- 結果 `api.github.com` / `hooks.slack.com` の双方へ通信できず、通知が送れないだけでなく**エラーアラートの Slack 投稿も同じ理由で失敗**するため、無言で停止していた。

## 調査時の証拠
| 確認項目 | 結果 |
|---|---|
| GitHub トークン | 有効（`/notifications` 200, `notifications` スコープ有り）→ 失効ではない |
| 未読通知 | **50 件蓄積**（正常なら投稿後 `PUT /notifications` で既読化される）→ 処理が完遂していない |
| Lambda 実行時間 | 全実行 約 17〜26ms → 外部 HTTPS が成立していない |
| `notifications body` ログ | 06-15 19:16 を最後に **0 件**（それ以前は毎分出力） |
| アラート | Slack へエラー通知も届かない → GitHub/Slack 両方不通 |

## 修正
ビルドのベースイメージを `crystallang/crystal:latest` → **`crystallang/crystal:latest-alpine`（musl）** に変更。musl は完全な静的バイナリでも外部通信が動く。

## 検証
`amazonlinux:2023`（= `provided.al2023` 相当, arm64）上で最小プログラムを実行し再現・確認済み:

- glibc 静的バイナリ → `FAIL OpenSSL::SSL::Error ... unregistered scheme` ❌
- musl 静的バイナリ → `OK status=200`（api.github.com への HTTPS 成功）✅

arm64 Alpine での `crystal build --link-flags -static` が通り、`statically linked ARM aarch64` バイナリが生成されることも確認済み。

## スコープ外（別 issue 化済み）
1. #90 **`env.yml` に GitHub トークン・Slack Webhook URL が平文でコミットされている**（現在もトークン有効）。ローテーション推奨。
2. #91 **連続失敗を検知する監視がない**（アラートも Slack 依存のため、今回のように外部通信全断だと機能しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)