### PR TITLE
feat: discordモードを追加し Slack / Discord を切り替え可能にする (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # github_notifications_slack
 [![serverless](https://github.com/limit7412/github_notifications_slack/actions/workflows/serverless-prod.yml/badge.svg?branch=master)](https://github.com/limit7412/github_notifications_slack/actions/workflows/serverless-prod.yml)
 
-  - githubのアカウントの通知をslackで流したい
+  - githubのアカウントの通知をslack / discordで流したい
   - crystal
   - aws lambda
   - serverless framework
@@ -10,6 +10,17 @@
 WEBHOOK_URL: <通知用webhook>
 ALERT_WEBHOOK_URL: <アラート用webhook>
 GITHUB_TOKEN: <token>
-SLACK_ID: <通知先ユーザーid>
+MENTION_ID: <メンション先ユーザーid（Slackなら U...、Discordならユーザーid）>
+NOTIFY_MODE: <slack | discord（省略時 slack）>
 ENV: <環境名>
 ```
+
+## 通知先の切り替え
+
+`NOTIFY_MODE` で通知・アラートの投稿先を切り替える。
+
+- `slack`（既定）: `WEBHOOK_URL` / `ALERT_WEBHOOK_URL` に Slack Incoming Webhook を設定
+- `discord`: 同変数に Discord Webhook URL を設定
+
+メンション先は `MENTION_ID` で指定する。Slack と Discord で ID 体系が異なるため、
+モードに合わせた ID を設定する。後方互換として `MENTION_ID` 未設定時は `SLACK_ID` を使う。

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 WEBHOOK_URL: <通知用webhook>
 ALERT_WEBHOOK_URL: <アラート用webhook>
 GITHUB_TOKEN: <token>
-MENTION_ID: <メンション先ユーザーid（Slackなら U...、Discordならユーザーid）>
 NOTIFY_MODE: <slack | discord（省略時 slack）>
 ENV: <環境名>
 ```
@@ -22,5 +21,8 @@ ENV: <環境名>
 - `slack`（既定）: `WEBHOOK_URL` / `ALERT_WEBHOOK_URL` に Slack Incoming Webhook を設定
 - `discord`: 同変数に Discord Webhook URL を設定
 
-メンション先は `MENTION_ID` で指定する。Slack と Discord で ID 体系が異なるため、
-モードに合わせた ID を設定する。後方互換として `MENTION_ID` 未設定時は `SLACK_ID` を使う。
+## メンション
+
+メンション対象の通知（mention 系 reason）とアラートは、チャンネル全体に通知する。
+Slack では `@channel`（`<!channel>`）、Discord では `@everyone` を使うため、
+ユーザー ID の設定は不要。

--- a/spec/discord/models_spec.cr
+++ b/spec/discord/models_spec.cr
@@ -82,6 +82,20 @@ describe Discord::Post do
       posts[2].embeds.size.should eq 3
     end
 
+    it "splits a chunk before the combined embed length exceeds 6000 chars" do
+      # 1 embed = title(2) + description(2900) = 2902 文字。
+      # 2 件で 5804 ≤ 6000 は同一メッセージ、3 件目で 8706 を超えるため分割される。
+      messages = Array.new(3) { |i| Notify::Message.new(title: "t#{i}", text: "d" * 2900) }
+      posts = Discord::Post.build(messages, "123")
+
+      posts.size.should eq 2
+      posts[0].embeds.size.should eq 2
+      posts[1].embeds.size.should eq 1
+      posts.each do |post|
+        post.embeds.sum(&.char_count).should be <= Discord::TOTAL_CHARS_LIMIT
+      end
+    end
+
     it "sets a mention in content when any message in a chunk mentions" do
       messages = [
         Notify::Message.new(title: "a"),

--- a/spec/discord/models_spec.cr
+++ b/spec/discord/models_spec.cr
@@ -1,0 +1,109 @@
+require "../spec_helper"
+
+describe Discord::Embed do
+  describe ".color_from_hex" do
+    it "converts a #RRGGBB string to its integer value" do
+      Discord::Embed.color_from_hex("#F6CEE3").should eq 0xF6CEE3
+      Discord::Embed.color_from_hex("000000").should eq 0
+      Discord::Embed.color_from_hex("#ffffff").should eq 0xFFFFFF
+    end
+
+    it "returns nil for a missing or invalid color" do
+      Discord::Embed.color_from_hex(nil).should be_nil
+      Discord::Embed.color_from_hex("#notacolor").should be_nil
+    end
+  end
+
+  describe ".from_message" do
+    it "merges pretext and text into the description" do
+      message = Notify::Message.new(pretext: "pre", text: "body")
+      embed = Discord::Embed.from_message(message)
+
+      embed.description.should eq "pre\n\nbody"
+    end
+
+    it "drops author and footer when their required fields are absent" do
+      embed = Discord::Embed.from_message(Notify::Message.new(title: "t"))
+
+      embed.author.should be_nil
+      embed.footer.should be_nil
+    end
+
+    it "builds author and footer from the message" do
+      message = Notify::Message.new(
+        author_name: "octocat",
+        author_link: "https://example.com/u",
+        author_icon: "https://example.com/a.png",
+        footer: "octocat/Hello-World",
+        footer_icon: "https://example.com/f.png",
+      )
+      embed = Discord::Embed.from_message(message)
+
+      author = embed.author.as(Discord::Author)
+      author.name.should eq "octocat"
+      author.url.should eq "https://example.com/u"
+      author.icon_url.should eq "https://example.com/a.png"
+
+      footer = embed.footer.as(Discord::Footer)
+      footer.text.should eq "octocat/Hello-World"
+      footer.icon_url.should eq "https://example.com/f.png"
+    end
+
+    it "truncates title and description to the Discord limits" do
+      message = Notify::Message.new(
+        title: "t" * (Discord::TITLE_LIMIT + 10),
+        text: "d" * (Discord::DESCRIPTION_LIMIT + 10),
+      )
+      embed = Discord::Embed.from_message(message)
+
+      embed.title.as(String).size.should eq Discord::TITLE_LIMIT
+      embed.description.as(String).size.should eq Discord::DESCRIPTION_LIMIT
+    end
+
+    it "omits unset fields when serialized" do
+      parsed = JSON.parse(Discord::Embed.from_message(Notify::Message.new(title: "t")).to_json)
+
+      parsed["title"].should eq "t"
+      parsed.as_h.has_key?("description").should be_false
+      parsed.as_h.has_key?("author").should be_false
+    end
+  end
+end
+
+describe Discord::Post do
+  describe ".build" do
+    it "chunks messages into posts of at most 10 embeds" do
+      messages = Array.new(23) { |i| Notify::Message.new(title: "t#{i}") }
+      posts = Discord::Post.build(messages, "123")
+
+      posts.size.should eq 3
+      posts[0].embeds.size.should eq 10
+      posts[1].embeds.size.should eq 10
+      posts[2].embeds.size.should eq 3
+    end
+
+    it "sets a mention in content when any message in a chunk mentions" do
+      messages = [
+        Notify::Message.new(title: "a"),
+        Notify::Message.new(title: "b", mention: true),
+      ]
+      posts = Discord::Post.build(messages, "123")
+
+      posts.size.should eq 1
+      posts[0].content.should eq "<@123>"
+    end
+
+    it "leaves content unset when no message mentions" do
+      posts = Discord::Post.build([Notify::Message.new(title: "a")], "123")
+
+      posts[0].content.should be_nil
+    end
+
+    it "serializes embeds under an embeds key" do
+      parsed = JSON.parse(Discord::Post.build([Notify::Message.new(title: "a")], "123")[0].to_json)
+
+      parsed["embeds"].as_a.size.should eq 1
+      parsed["embeds"][0]["title"].should eq "a"
+    end
+  end
+end

--- a/spec/discord/models_spec.cr
+++ b/spec/discord/models_spec.cr
@@ -49,6 +49,28 @@ describe Discord::Embed do
       footer.icon_url.should eq "https://example.com/f.png"
     end
 
+    it "drops empty url / icon fields so Discord does not reject them" do
+      # アラートは footer_icon: "" で来るため、空文字は nil として出さない
+      message = Notify::Message.new(
+        author_name: "octocat",
+        author_link: "",
+        author_icon: "",
+        title_link: "",
+        footer: "github",
+        footer_icon: "",
+      )
+      embed = Discord::Embed.from_message(message)
+
+      embed.url.should be_nil
+      embed.author.as(Discord::Author).url.should be_nil
+      embed.author.as(Discord::Author).icon_url.should be_nil
+      embed.footer.as(Discord::Footer).icon_url.should be_nil
+
+      # 空文字フィールドはシリアライズされない
+      parsed = JSON.parse(embed.to_json)
+      parsed["footer"].as_h.has_key?("icon_url").should be_false
+    end
+
     it "truncates title and description to the Discord limits" do
       message = Notify::Message.new(
         title: "t" * (Discord::TITLE_LIMIT + 10),

--- a/spec/discord/models_spec.cr
+++ b/spec/discord/models_spec.cr
@@ -96,7 +96,7 @@ describe Discord::Post do
   describe ".build" do
     it "chunks messages into posts of at most 10 embeds" do
       messages = Array.new(23) { |i| Notify::Message.new(title: "t#{i}") }
-      posts = Discord::Post.build(messages, "123")
+      posts = Discord::Post.build(messages)
 
       posts.size.should eq 3
       posts[0].embeds.size.should eq 10
@@ -108,7 +108,7 @@ describe Discord::Post do
       # 1 embed = title(2) + description(2900) = 2902 文字。
       # 2 件で 5804 ≤ 6000 は同一メッセージ、3 件目で 8706 を超えるため分割される。
       messages = Array.new(3) { |i| Notify::Message.new(title: "t#{i}", text: "d" * 2900) }
-      posts = Discord::Post.build(messages, "123")
+      posts = Discord::Post.build(messages)
 
       posts.size.should eq 2
       posts[0].embeds.size.should eq 2
@@ -118,25 +118,25 @@ describe Discord::Post do
       end
     end
 
-    it "sets a mention in content when any message in a chunk mentions" do
+    it "sets a channel-wide mention in content when any message in a chunk mentions" do
       messages = [
         Notify::Message.new(title: "a"),
         Notify::Message.new(title: "b", mention: true),
       ]
-      posts = Discord::Post.build(messages, "123")
+      posts = Discord::Post.build(messages)
 
       posts.size.should eq 1
-      posts[0].content.should eq "<@123>"
+      posts[0].content.should eq "@everyone"
     end
 
     it "leaves content unset when no message mentions" do
-      posts = Discord::Post.build([Notify::Message.new(title: "a")], "123")
+      posts = Discord::Post.build([Notify::Message.new(title: "a")])
 
       posts[0].content.should be_nil
     end
 
     it "serializes embeds under an embeds key" do
-      parsed = JSON.parse(Discord::Post.build([Notify::Message.new(title: "a")], "123")[0].to_json)
+      parsed = JSON.parse(Discord::Post.build([Notify::Message.new(title: "a")])[0].to_json)
 
       parsed["embeds"].as_a.size.should eq 1
       parsed["embeds"][0]["title"].should eq "a"

--- a/spec/slack/models_spec.cr
+++ b/spec/slack/models_spec.cr
@@ -11,18 +11,18 @@ describe Slack::Attachment do
   end
 
   describe ".from_message" do
-    it "prefixes the pretext with a mention when the message mentions the user" do
+    it "prefixes the pretext with a channel-wide mention when the message mentions" do
       message = Notify::Message.new(mention: true, pretext: "hello", text: "body")
-      attachment = Slack::Attachment.from_message(message, "U123")
+      attachment = Slack::Attachment.from_message(message)
 
-      attachment.pretext.should eq "<@U123> hello"
+      attachment.pretext.should eq "<!channel> hello"
       # fallback は生の pretext を保持する
       attachment.fallback.should eq "hello"
     end
 
     it "leaves the pretext untouched when the message does not mention" do
       message = Notify::Message.new(mention: false, pretext: "hello")
-      attachment = Slack::Attachment.from_message(message, "U123")
+      attachment = Slack::Attachment.from_message(message)
 
       attachment.pretext.should eq "hello"
     end
@@ -44,7 +44,7 @@ describe Slack::Post do
         Notify::Message.new(pretext: "first"),
         Notify::Message.new(pretext: "second"),
       ]
-      post = Slack::Post.build(messages, "U123")
+      post = Slack::Post.build(messages)
 
       post.attachments.size.should eq 2
       post.attachments[0].pretext.should eq "first"

--- a/spec/slack/models_spec.cr
+++ b/spec/slack/models_spec.cr
@@ -9,6 +9,24 @@ describe Slack::Attachment do
     parsed["color"].should eq "#000000"
     parsed.as_h.has_key?("title").should be_false
   end
+
+  describe ".from_message" do
+    it "prefixes the pretext with a mention when the message mentions the user" do
+      message = Notify::Message.new(mention: true, pretext: "hello", text: "body")
+      attachment = Slack::Attachment.from_message(message, "U123")
+
+      attachment.pretext.should eq "<@U123> hello"
+      # fallback は生の pretext を保持する
+      attachment.fallback.should eq "hello"
+    end
+
+    it "leaves the pretext untouched when the message does not mention" do
+      message = Notify::Message.new(mention: false, pretext: "hello")
+      attachment = Slack::Attachment.from_message(message, "U123")
+
+      attachment.pretext.should eq "hello"
+    end
+  end
 end
 
 describe Slack::Post do
@@ -18,5 +36,19 @@ describe Slack::Post do
 
     parsed["attachments"].as_a.size.should eq 1
     parsed["attachments"][0]["text"].should eq "a"
+  end
+
+  describe ".build" do
+    it "converts every message to an attachment" do
+      messages = [
+        Notify::Message.new(pretext: "first"),
+        Notify::Message.new(pretext: "second"),
+      ]
+      post = Slack::Post.build(messages, "U123")
+
+      post.attachments.size.should eq 2
+      post.attachments[0].pretext.should eq "first"
+      post.attachments[1].pretext.should eq "second"
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,5 @@
 require "spec"
 require "../src/github/models"
+require "../src/notify/models"
 require "../src/slack/models"
+require "../src/discord/models"

--- a/src/discord/models.cr
+++ b/src/discord/models.cr
@@ -9,6 +9,9 @@ module Discord
   DESCRIPTION_LIMIT  = 4096 # embed description 最大 4096 文字
   TITLE_LIMIT        =  256 # embed title 最大 256 文字
 
+  # メンション時はチャンネル全体（@everyone）に通知する。
+  EVERYONE_MENTION = "@everyone"
+
   def self.truncate(text : String, limit : Int32) : String
     text.size > limit ? text[0, limit] : text
   end
@@ -25,7 +28,7 @@ module Discord
     # 中立メッセージ列を Discord の投稿単位へ分割して組み立てる。
     # embeds は最大 10 件、かつ 1 メッセージ内 embeds の合計文字数が 6000 を
     # 超えないよう詰め込む（超過すると Discord が 400 を返すため）。
-    def self.build(messages : Array(Notify::Message), mention_id : String) : Array(Post)
+    def self.build(messages : Array(Notify::Message)) : Array(Post)
       posts = [] of Post
       chunk = [] of Embed
       chunk_chars = 0
@@ -33,7 +36,7 @@ module Discord
 
       flush = -> do
         return if chunk.empty?
-        posts << Post.new(chunk, mention_content(mention, mention_id))
+        posts << Post.new(chunk, mention_content(mention))
         chunk = [] of Embed
         chunk_chars = 0
         mention = false
@@ -55,8 +58,8 @@ module Discord
     end
 
     # メンションは embed 内では機能しないため content に出力する。
-    private def self.mention_content(mention : Bool, mention_id : String) : String?
-      Discord.truncate("<@#{mention_id}>", CONTENT_LIMIT) if mention
+    private def self.mention_content(mention : Bool) : String?
+      EVERYONE_MENTION if mention
     end
   end
 

--- a/src/discord/models.cr
+++ b/src/discord/models.cr
@@ -4,6 +4,7 @@ require "../notify/models"
 module Discord
   # Discord の制約値。
   EMBEDS_PER_MESSAGE =   10 # 1 メッセージあたり embeds 最大 10 件
+  TOTAL_CHARS_LIMIT  = 6000 # 1 メッセージ内 embeds 合計文字数の上限
   CONTENT_LIMIT      = 2000 # content 最大 2000 文字
   DESCRIPTION_LIMIT  = 4096 # embed description 最大 4096 文字
   TITLE_LIMIT        =  256 # embed title 最大 256 文字
@@ -21,16 +22,41 @@ module Discord
     def initialize(@embeds, @content = nil)
     end
 
-    # 中立メッセージ列を Discord の投稿単位（embeds 最大 10 件）へ分割して組み立てる。
+    # 中立メッセージ列を Discord の投稿単位へ分割して組み立てる。
+    # embeds は最大 10 件、かつ 1 メッセージ内 embeds の合計文字数が 6000 を
+    # 超えないよう詰め込む（超過すると Discord が 400 を返すため）。
     def self.build(messages : Array(Notify::Message), mention_id : String) : Array(Post)
-      messages.each_slice(EMBEDS_PER_MESSAGE).map do |chunk|
-        # メンションは embed 内では機能しないため content に出力する。
-        content =
-          if chunk.any?(&.mention?)
-            Discord.truncate("<@#{mention_id}>", CONTENT_LIMIT)
-          end
-        Post.new(chunk.map { |message| Embed.from_message(message) }, content)
-      end.to_a
+      posts = [] of Post
+      chunk = [] of Embed
+      chunk_chars = 0
+      mention = false
+
+      flush = -> do
+        return if chunk.empty?
+        posts << Post.new(chunk, mention_content(mention, mention_id))
+        chunk = [] of Embed
+        chunk_chars = 0
+        mention = false
+      end
+
+      messages.each do |message|
+        embed = Embed.from_message(message)
+        size = embed.char_count
+        if !chunk.empty? && (chunk.size >= EMBEDS_PER_MESSAGE || chunk_chars + size > TOTAL_CHARS_LIMIT)
+          flush.call
+        end
+        chunk << embed
+        chunk_chars += size
+        mention = true if message.mention?
+      end
+      flush.call
+
+      posts
+    end
+
+    # メンションは embed 内では機能しないため content に出力する。
+    private def self.mention_content(mention : Bool, mention_id : String) : String?
+      Discord.truncate("<@#{mention_id}>", CONTENT_LIMIT) if mention
     end
   end
 
@@ -52,6 +78,14 @@ module Discord
       @author = nil,
       @footer = nil,
     )
+    end
+
+    # Discord の 6000 文字制限が対象とするフィールド（title / description /
+    # author.name / footer.text）の合計文字数。
+    def char_count : Int32
+      [title, description, author.try(&.name), footer.try(&.text)]
+        .compact
+        .sum(&.size)
     end
 
     def self.from_message(message : Notify::Message) : Embed

--- a/src/discord/models.cr
+++ b/src/discord/models.cr
@@ -1,0 +1,114 @@
+require "json"
+require "../notify/models"
+
+module Discord
+  # Discord の制約値。
+  EMBEDS_PER_MESSAGE =   10 # 1 メッセージあたり embeds 最大 10 件
+  CONTENT_LIMIT      = 2000 # content 最大 2000 文字
+  DESCRIPTION_LIMIT  = 4096 # embed description 最大 4096 文字
+  TITLE_LIMIT        =  256 # embed title 最大 256 文字
+
+  def self.truncate(text : String, limit : Int32) : String
+    text.size > limit ? text[0, limit] : text
+  end
+
+  class Post
+    include JSON::Serializable
+
+    getter content : String?
+    getter embeds : Array(Embed)
+
+    def initialize(@embeds, @content = nil)
+    end
+
+    # 中立メッセージ列を Discord の投稿単位（embeds 最大 10 件）へ分割して組み立てる。
+    def self.build(messages : Array(Notify::Message), mention_id : String) : Array(Post)
+      messages.each_slice(EMBEDS_PER_MESSAGE).map do |chunk|
+        # メンションは embed 内では機能しないため content に出力する。
+        content =
+          if chunk.any?(&.mention?)
+            Discord.truncate("<@#{mention_id}>", CONTENT_LIMIT)
+          end
+        Post.new(chunk.map { |message| Embed.from_message(message) }, content)
+      end.to_a
+    end
+  end
+
+  class Embed
+    include JSON::Serializable
+
+    getter title : String?
+    getter url : String?
+    getter description : String?
+    getter color : Int32?
+    getter author : Author?
+    getter footer : Footer?
+
+    def initialize(
+      @title = nil,
+      @url = nil,
+      @description = nil,
+      @color = nil,
+      @author = nil,
+      @footer = nil,
+    )
+    end
+
+    def self.from_message(message : Notify::Message) : Embed
+      # Slack の pretext 相当の欄が embed には無いため text とまとめて description にする。
+      description = [message.pretext, message.text]
+        .compact
+        .reject(&.empty?)
+        .join("\n\n")
+        .presence
+
+      Embed.new(
+        title: message.title.try { |value| Discord.truncate(value, TITLE_LIMIT) },
+        url: message.title_link,
+        description: description.try { |value| Discord.truncate(value, DESCRIPTION_LIMIT) },
+        color: color_from_hex(message.color),
+        author: Author.from_message(message),
+        footer: Footer.from_message(message),
+      )
+    end
+
+    # Slack で使う "#RRGGBB" 形式の色を Discord が要求する Int32 へ変換する。
+    def self.color_from_hex(hex : String?) : Int32?
+      return nil unless hex
+      hex.lchop('#').to_i?(16)
+    end
+  end
+
+  class Author
+    include JSON::Serializable
+
+    getter name : String?
+    getter url : String?
+    getter icon_url : String?
+
+    def initialize(@name = nil, @url = nil, @icon_url = nil)
+    end
+
+    def self.from_message(message : Notify::Message) : Author?
+      # Discord は author に name 必須のため、名前が無ければ author 自体を付けない。
+      return nil unless message.author_name
+      Author.new(message.author_name, message.author_link, message.author_icon)
+    end
+  end
+
+  class Footer
+    include JSON::Serializable
+
+    getter text : String?
+    getter icon_url : String?
+
+    def initialize(@text = nil, @icon_url = nil)
+    end
+
+    def self.from_message(message : Notify::Message) : Footer?
+      # Discord は footer に text 必須のため、footer が無ければ付けない。
+      return nil unless message.footer
+      Footer.new(message.footer, message.footer_icon)
+    end
+  end
+end

--- a/src/discord/models.cr
+++ b/src/discord/models.cr
@@ -98,7 +98,8 @@ module Discord
 
       Embed.new(
         title: message.title.try { |value| Discord.truncate(value, TITLE_LIMIT) },
-        url: message.title_link,
+        # 空文字の URL は Discord に 400 で弾かれるため nil にする。
+        url: message.title_link.presence,
         description: description.try { |value| Discord.truncate(value, DESCRIPTION_LIMIT) },
         color: color_from_hex(message.color),
         author: Author.from_message(message),
@@ -126,7 +127,8 @@ module Discord
     def self.from_message(message : Notify::Message) : Author?
       # Discord は author に name 必須のため、名前が無ければ author 自体を付けない。
       return nil unless message.author_name
-      Author.new(message.author_name, message.author_link, message.author_icon)
+      # 空文字の URL は Discord に 400 で弾かれるため nil にする。
+      Author.new(message.author_name, message.author_link.presence, message.author_icon.presence)
     end
   end
 
@@ -142,7 +144,9 @@ module Discord
     def self.from_message(message : Notify::Message) : Footer?
       # Discord は footer に text 必須のため、footer が無ければ付けない。
       return nil unless message.footer
-      Footer.new(message.footer, message.footer_icon)
+      # 空文字の icon_url は Discord に 400 で弾かれるため nil にする
+      # （アラートは footer_icon: "" で来るため特に重要）。
+      Footer.new(message.footer, message.footer_icon.presence)
     end
   end
 end

--- a/src/discord/repository.cr
+++ b/src/discord/repository.cr
@@ -10,13 +10,13 @@ module Discord
     MAX_SEND_ATTEMPTS = 3         # 送信リトライ回数の上限
     MAX_RETRY_WAIT    = 5.seconds # Retry-After の待機上限
 
-    def initialize(url : String, @mention_id : String)
+    def initialize(url : String)
       @uri = URI.parse url
       @client = HTTP::Client.new @uri
     end
 
     def send_messages(messages : Array(Notify::Message))
-      Post.build(messages, @mention_id).each { |post| send_post post }
+      Post.build(messages).each { |post| send_post post }
     end
 
     private def send_post(post : Post)

--- a/src/discord/repository.cr
+++ b/src/discord/repository.cr
@@ -1,0 +1,31 @@
+require "json"
+require "uri"
+require "http/client"
+require "./models"
+require "../notify/models"
+require "../notify/poster"
+
+module Discord
+  class PostRepository < Notify::Poster
+    def initialize(url : String, @mention_id : String)
+      @uri = URI.parse url
+      @client = HTTP::Client.new @uri
+    end
+
+    def send_messages(messages : Array(Notify::Message))
+      Post.build(messages, @mention_id).each { |post| send_post post }
+    end
+
+    private def send_post(post : Post)
+      res = @client.post(
+        @uri.request_target,
+        headers: HTTP::Headers{"Content-Type" => "application/json"},
+        body: post.to_json,
+      )
+      # 429（レート制限）などの失敗時は例外にして既読化を止め、次回実行に委ねる。
+      unless res.success?
+        raise "discord webhook returned #{res.status_code}: #{res.body}"
+      end
+    end
+  end
+end

--- a/src/discord/repository.cr
+++ b/src/discord/repository.cr
@@ -3,10 +3,10 @@ require "uri"
 require "http/client"
 require "./models"
 require "../notify/models"
-require "../notify/poster"
+require "../notify/repository"
 
 module Discord
-  class PostRepository < Notify::Poster
+  class PostRepository < Notify::PostRepository
     MAX_SEND_ATTEMPTS = 3         # 送信リトライ回数の上限
     MAX_RETRY_WAIT    = 5.seconds # Retry-After の待機上限
 

--- a/src/discord/repository.cr
+++ b/src/discord/repository.cr
@@ -7,6 +7,9 @@ require "../notify/poster"
 
 module Discord
   class PostRepository < Notify::Poster
+    MAX_SEND_ATTEMPTS = 3         # 送信リトライ回数の上限
+    MAX_RETRY_WAIT    = 5.seconds # Retry-After の待機上限
+
     def initialize(url : String, @mention_id : String)
       @uri = URI.parse url
       @client = HTTP::Client.new @uri
@@ -17,15 +20,32 @@ module Discord
     end
 
     private def send_post(post : Post)
-      res = @client.post(
-        @uri.request_target,
-        headers: HTTP::Headers{"Content-Type" => "application/json"},
-        body: post.to_json,
-      )
-      # 429（レート制限）などの失敗時は例外にして既読化を止め、次回実行に委ねる。
-      unless res.success?
+      body = post.to_json
+      headers = HTTP::Headers{"Content-Type" => "application/json"}
+
+      attempt = 0
+      loop do
+        attempt += 1
+        res = @client.post(@uri.request_target, headers: headers, body: body)
+        return if res.success?
+
+        # 通知が複数投稿に分割される場合、前半チャンク送信後に後半が 429/5xx で
+        # 失敗すると既読化されず、次回実行で前半が重複投稿される。これを避けるため
+        # レート制限・一時的な 5xx は Retry-After に従って再送する。
+        retryable = res.status.code == 429 || res.status.server_error?
+        if retryable && attempt < MAX_SEND_ATTEMPTS
+          sleep retry_after(res)
+          next
+        end
+
+        # 恒久的な失敗時は例外にして既読化を止め、次回実行に委ねる。
         raise "discord webhook returned #{res.status_code}: #{res.body}"
       end
+    end
+
+    private def retry_after(res : HTTP::Client::Response) : Time::Span
+      seconds = res.headers["Retry-After"]?.try(&.to_f?) || 1.0
+      seconds.seconds.clamp(Time::Span.zero, MAX_RETRY_WAIT)
     end
   end
 end

--- a/src/error/usecase.cr
+++ b/src/error/usecase.cr
@@ -1,9 +1,9 @@
 require "../notify/models"
-require "../notify/poster"
+require "../notify/repository"
 
 module Error
   class Usecase
-    def initialize(@poster : Notify::Poster, @env : String)
+    def initialize(@poster : Notify::PostRepository, @env : String)
     end
 
     def alert(err)

--- a/src/error/usecase.cr
+++ b/src/error/usecase.cr
@@ -1,23 +1,22 @@
-require "../slack/models"
-require "../slack/repository"
+require "../notify/models"
+require "../notify/poster"
 
 module Error
   class Usecase
-    def initialize(@slack_repo : Slack::PostRepository, @slack_id : String, @env : String)
+    def initialize(@poster : Notify::Poster, @env : String)
     end
 
     def alert(err)
       message = "エラーみたい…確認してみよっか"
-      attachment = Slack::Attachment.new(
-        fallback: message,
-        pretext: "<@#{@slack_id}> #{message}",
+      @poster.send_message Notify::Message.new(
+        mention: true,
+        pretext: message,
         color: "#EB4646",
         title: err.message,
         text: err.backtrace?.try(&.join('\n')),
         footer: "github_notifications_slack (#{@env})",
         footer_icon: "",
       )
-      @slack_repo.send_attachment attachment
 
       {msg: "ng"}
     end

--- a/src/github/usecase.cr
+++ b/src/github/usecase.cr
@@ -1,20 +1,20 @@
 require "./models"
 require "./repository"
-require "../slack/models"
+require "../notify/models"
 
 module Github
   class Usecase
-    def initialize(@repo : NotificationRepository, @slack_id : String)
+    def initialize(@repo : NotificationRepository)
     end
 
-    def to_slack_attachment(notify : Notification, pretext : String, message : String) : Slack::Attachment
+    def build_message(notify : Notification, pretext : String) : Notify::Message
       comment = @repo.find_comment_by_url notify.subject.comment_url
-      Slack::Attachment.new(
-        fallback: pretext,
+      Notify::Message.new(
+        mention: notify.mention?,
         author_name: comment.user.login,
         author_icon: comment.user.avatar_url,
         author_link: comment.user.html_url,
-        pretext: "#{notify.mention? ? "<@#{@slack_id}> " : ""}#{pretext}",
+        pretext: pretext,
         color: notify.subject.color,
         title: notify.subject.title,
         title_link: comment.html_url,

--- a/src/main.cr
+++ b/src/main.cr
@@ -2,7 +2,7 @@ require "./runtime/lambda"
 require "./github/repository"
 require "./github/usecase"
 require "./notify/usecase"
-require "./notify/poster"
+require "./notify/repository"
 require "./slack/repository"
 require "./discord/repository"
 require "./error/usecase"
@@ -21,7 +21,7 @@ APP_ENV     = ENV["ENV"]
 # NOTIFY_MODE に応じて送信先アダプタを生成する。
 # 未設定時は既定の slack だが、想定外の値（typo 等）は起動時に例外にして
 # 設定ミスに気づけるようにする（Slack 形式を Discord webhook へ誤送しない）。
-def build_poster(url : String) : Notify::Poster
+def build_poster(url : String) : Notify::PostRepository
   case NOTIFY_MODE
   when "slack"
     Slack::PostRepository.new(url, MENTION_ID)

--- a/src/main.cr
+++ b/src/main.cr
@@ -2,27 +2,41 @@ require "./runtime/lambda"
 require "./github/repository"
 require "./github/usecase"
 require "./notify/usecase"
+require "./notify/poster"
 require "./slack/repository"
+require "./discord/repository"
 require "./error/usecase"
 
 # 必須の環境変数は起動時に解決し、欠如していればこの時点で失敗させる。
 GITHUB_TOKEN      = ENV["GITHUB_TOKEN"]
 WEBHOOK_URL       = ENV["WEBHOOK_URL"]
 ALERT_WEBHOOK_URL = ENV["ALERT_WEBHOOK_URL"]
-SLACK_ID          = ENV["SLACK_ID"]
-APP_ENV           = ENV["ENV"]
+# メンション先 ID は Slack / Discord で体系が異なるため一般化する。
+# 後方互換として未設定時は従来の SLACK_ID を使う。
+MENTION_ID  = ENV["MENTION_ID"]? || ENV["SLACK_ID"]
+NOTIFY_MODE = ENV["NOTIFY_MODE"]? || "slack"
+APP_ENV     = ENV["ENV"]
+
+# NOTIFY_MODE に応じて送信先アダプタを生成する。
+def build_poster(url : String) : Notify::Poster
+  case NOTIFY_MODE
+  when "discord"
+    Discord::PostRepository.new(url, MENTION_ID)
+  else
+    Slack::PostRepository.new(url, MENTION_ID)
+  end
+end
 
 # 依存はコールドスタート時に一度だけ生成し、ウォームスタート間で使い回すことで
 # HTTP::Client のコネクション（TCP/SSL）を再利用する。
 github_repo = Github::NotificationRepository.new GITHUB_TOKEN
 notify_uc = Notify::Usecase.new(
   github_repo,
-  Github::Usecase.new(github_repo, SLACK_ID),
-  Slack::PostRepository.new(WEBHOOK_URL),
+  Github::Usecase.new(github_repo),
+  build_poster(WEBHOOK_URL),
 )
 error_uc = Error::Usecase.new(
-  Slack::PostRepository.new(ALERT_WEBHOOK_URL),
-  SLACK_ID,
+  build_poster(ALERT_WEBHOOK_URL),
   APP_ENV,
 )
 

--- a/src/main.cr
+++ b/src/main.cr
@@ -12,8 +12,9 @@ GITHUB_TOKEN      = ENV["GITHUB_TOKEN"]
 WEBHOOK_URL       = ENV["WEBHOOK_URL"]
 ALERT_WEBHOOK_URL = ENV["ALERT_WEBHOOK_URL"]
 # メンション先 ID は Slack / Discord で体系が異なるため一般化する。
-# 後方互換として未設定時は従来の SLACK_ID を使う。
-MENTION_ID  = ENV["MENTION_ID"]? || ENV["SLACK_ID"]
+# 後方互換として未設定時は従来の SLACK_ID を使い、どちらも無ければ明示的に失敗させる。
+MENTION_ID = ENV["MENTION_ID"]? || ENV["SLACK_ID"]? ||
+             raise "Missing ENV key: \"MENTION_ID\" (fallback \"SLACK_ID\" も未設定)"
 NOTIFY_MODE = ENV["NOTIFY_MODE"]? || "slack"
 APP_ENV     = ENV["ENV"]
 

--- a/src/main.cr
+++ b/src/main.cr
@@ -19,12 +19,16 @@ NOTIFY_MODE = ENV["NOTIFY_MODE"]? || "slack"
 APP_ENV     = ENV["ENV"]
 
 # NOTIFY_MODE に応じて送信先アダプタを生成する。
+# 未設定時は既定の slack だが、想定外の値（typo 等）は起動時に例外にして
+# 設定ミスに気づけるようにする（Slack 形式を Discord webhook へ誤送しない）。
 def build_poster(url : String) : Notify::Poster
   case NOTIFY_MODE
+  when "slack"
+    Slack::PostRepository.new(url, MENTION_ID)
   when "discord"
     Discord::PostRepository.new(url, MENTION_ID)
   else
-    Slack::PostRepository.new(url, MENTION_ID)
+    raise %(Unknown NOTIFY_MODE: #{NOTIFY_MODE.inspect} (expected "slack" or "discord"))
   end
 end
 

--- a/src/main.cr
+++ b/src/main.cr
@@ -11,12 +11,8 @@ require "./error/usecase"
 GITHUB_TOKEN      = ENV["GITHUB_TOKEN"]
 WEBHOOK_URL       = ENV["WEBHOOK_URL"]
 ALERT_WEBHOOK_URL = ENV["ALERT_WEBHOOK_URL"]
-# メンション先 ID は Slack / Discord で体系が異なるため一般化する。
-# 後方互換として未設定時は従来の SLACK_ID を使い、どちらも無ければ明示的に失敗させる。
-MENTION_ID = ENV["MENTION_ID"]? || ENV["SLACK_ID"]? ||
-             raise "Missing ENV key: \"MENTION_ID\" (fallback \"SLACK_ID\" も未設定)"
-NOTIFY_MODE = ENV["NOTIFY_MODE"]? || "slack"
-APP_ENV     = ENV["ENV"]
+NOTIFY_MODE       = ENV["NOTIFY_MODE"]? || "slack"
+APP_ENV           = ENV["ENV"]
 
 # NOTIFY_MODE に応じて送信先アダプタを生成する。
 # 未設定時は既定の slack だが、想定外の値（typo 等）は起動時に例外にして
@@ -24,9 +20,9 @@ APP_ENV     = ENV["ENV"]
 def build_poster(url : String) : Notify::PostRepository
   case NOTIFY_MODE
   when "slack"
-    Slack::PostRepository.new(url, MENTION_ID)
+    Slack::PostRepository.new(url)
   when "discord"
-    Discord::PostRepository.new(url, MENTION_ID)
+    Discord::PostRepository.new(url)
   else
     raise %(Unknown NOTIFY_MODE: #{NOTIFY_MODE.inspect} (expected "slack" or "discord"))
   end

--- a/src/notify/models.cr
+++ b/src/notify/models.cr
@@ -1,0 +1,32 @@
+module Notify
+  # 送信先に依存しない中立な通知メッセージ。
+  # Slack / Discord などのアダプタがそれぞれの形式へ変換する。
+  class Message
+    getter? mention : Bool
+    getter author_name : String?
+    getter author_icon : String?
+    getter author_link : String?
+    getter pretext : String?
+    getter color : String?
+    getter title : String?
+    getter title_link : String?
+    getter text : String?
+    getter footer : String?
+    getter footer_icon : String?
+
+    def initialize(
+      @mention = false,
+      @author_name = nil,
+      @author_icon = nil,
+      @author_link = nil,
+      @pretext = nil,
+      @color = nil,
+      @title = nil,
+      @title_link = nil,
+      @text = nil,
+      @footer = nil,
+      @footer_icon = nil,
+    )
+    end
+  end
+end

--- a/src/notify/poster.cr
+++ b/src/notify/poster.cr
@@ -1,0 +1,13 @@
+require "./models"
+
+module Notify
+  # 通知の送信先を抽象化するインターフェース。
+  # Slack::PostRepository / Discord::PostRepository が実装する。
+  abstract class Poster
+    abstract def send_messages(messages : Array(Message))
+
+    def send_message(message : Message)
+      send_messages [message]
+    end
+  end
+end

--- a/src/notify/repository.cr
+++ b/src/notify/repository.cr
@@ -3,7 +3,7 @@ require "./models"
 module Notify
   # 通知の送信先を抽象化するインターフェース。
   # Slack::PostRepository / Discord::PostRepository が実装する。
-  abstract class Poster
+  abstract class PostRepository
     abstract def send_messages(messages : Array(Message))
 
     def send_message(message : Message)

--- a/src/notify/usecase.cr
+++ b/src/notify/usecase.cr
@@ -1,13 +1,13 @@
 require "../github/repository"
 require "../github/usecase"
-require "./poster"
+require "./repository"
 
 module Notify
   class Usecase
     def initialize(
       @github_repo : Github::NotificationRepository,
       @github_uc : Github::Usecase,
-      @poster : Notify::Poster,
+      @poster : Notify::PostRepository,
     )
     end
 

--- a/src/notify/usecase.cr
+++ b/src/notify/usecase.cr
@@ -1,13 +1,13 @@
 require "../github/repository"
 require "../github/usecase"
-require "../slack/repository"
+require "./poster"
 
 module Notify
   class Usecase
     def initialize(
       @github_repo : Github::NotificationRepository,
       @github_uc : Github::Usecase,
-      @slack_repo : Slack::PostRepository,
+      @poster : Notify::Poster,
     )
     end
 
@@ -23,11 +23,11 @@ module Notify
             end
           pretext = "[#{item.subject.type}] #{message}"
 
-          @github_uc.to_slack_attachment item, pretext, message
+          @github_uc.build_message item, pretext
         end
 
       unless notices.empty?
-        @slack_repo.send_attachments notices
+        @poster.send_messages notices
         @github_repo.notification_to_read
       end
 

--- a/src/slack/models.cr
+++ b/src/slack/models.cr
@@ -32,10 +32,13 @@ module Slack
     )
     end
 
-    def self.from_message(message : Notify::Message, mention_id : String) : Attachment
+    # メンション時はチャンネル全体（@channel）に通知する。
+    CHANNEL_MENTION = "<!channel>"
+
+    def self.from_message(message : Notify::Message) : Attachment
       pretext =
         if message.mention?
-          "<@#{mention_id}> #{message.pretext}"
+          "#{CHANNEL_MENTION} #{message.pretext}"
         else
           message.pretext
         end
@@ -64,8 +67,8 @@ module Slack
     def initialize(@attachments)
     end
 
-    def self.build(messages : Array(Notify::Message), mention_id : String) : Post
-      Post.new(messages.map { |message| Attachment.from_message(message, mention_id) })
+    def self.build(messages : Array(Notify::Message)) : Post
+      Post.new(messages.map { |message| Attachment.from_message(message) })
     end
   end
 end

--- a/src/slack/models.cr
+++ b/src/slack/models.cr
@@ -1,4 +1,5 @@
 require "json"
+require "../notify/models"
 
 module Slack
   class Attachment
@@ -30,6 +31,29 @@ module Slack
       @footer_icon = nil,
     )
     end
+
+    def self.from_message(message : Notify::Message, mention_id : String) : Attachment
+      pretext =
+        if message.mention?
+          "<@#{mention_id}> #{message.pretext}"
+        else
+          message.pretext
+        end
+
+      Attachment.new(
+        fallback: message.pretext,
+        author_name: message.author_name,
+        author_icon: message.author_icon,
+        author_link: message.author_link,
+        pretext: pretext,
+        color: message.color,
+        title: message.title,
+        title_link: message.title_link,
+        text: message.text,
+        footer: message.footer,
+        footer_icon: message.footer_icon,
+      )
+    end
   end
 
   class Post
@@ -38,6 +62,10 @@ module Slack
     getter attachments : Array(Attachment)
 
     def initialize(@attachments)
+    end
+
+    def self.build(messages : Array(Notify::Message), mention_id : String) : Post
+      Post.new(messages.map { |message| Attachment.from_message(message, mention_id) })
     end
   end
 end

--- a/src/slack/repository.cr
+++ b/src/slack/repository.cr
@@ -3,10 +3,10 @@ require "uri"
 require "http/client"
 require "./models"
 require "../notify/models"
-require "../notify/poster"
+require "../notify/repository"
 
 module Slack
-  class PostRepository < Notify::Poster
+  class PostRepository < Notify::PostRepository
     def initialize(url : String, @mention_id : String)
       @uri = URI.parse url
       @client = HTTP::Client.new @uri

--- a/src/slack/repository.cr
+++ b/src/slack/repository.cr
@@ -7,13 +7,13 @@ require "../notify/repository"
 
 module Slack
   class PostRepository < Notify::PostRepository
-    def initialize(url : String, @mention_id : String)
+    def initialize(url : String)
       @uri = URI.parse url
       @client = HTTP::Client.new @uri
     end
 
     def send_messages(messages : Array(Notify::Message))
-      send_post Post.build(messages, @mention_id)
+      send_post Post.build(messages)
     end
 
     private def send_post(post : Post)

--- a/src/slack/repository.cr
+++ b/src/slack/repository.cr
@@ -2,20 +2,18 @@ require "json"
 require "uri"
 require "http/client"
 require "./models"
+require "../notify/models"
+require "../notify/poster"
 
 module Slack
-  class PostRepository
-    def initialize(url : String)
+  class PostRepository < Notify::Poster
+    def initialize(url : String, @mention_id : String)
       @uri = URI.parse url
       @client = HTTP::Client.new @uri
     end
 
-    def send_attachment(attachment : Attachment)
-      send_attachments [attachment]
-    end
-
-    def send_attachments(attachments : Array(Attachment))
-      send_post Post.new(attachments)
+    def send_messages(messages : Array(Notify::Message))
+      send_post Post.build(messages, @mention_id)
     end
 
     private def send_post(post : Post)


### PR DESCRIPTION
## 概要

issue #92 の実装。環境変数 `NOTIFY_MODE`（`slack` | `discord`、既定 `slack`）で通知・アラートの投稿先を切り替えられるようにした。usecase 層から Slack 依存を外し、送信先非依存の通知モデル + 送信インターフェースを導入して Slack / Discord をアダプタとして差し替え可能にした。Alert も同じ仕組みに乗るため Discord へ移行できる。

## 変更内容

### 中立モデルと送信インターフェース
- `src/notify/models.cr`: `Notify::Message` — 送信先非依存の通知情報を保持
- `src/notify/poster.cr`: `Notify::Poster` — `send_messages` を持つ抽象インターフェース

### Discord アダプタ
- `src/discord/models.cr`: `Discord::Post` / `Embed` / `Author` / `Footer`
  - hex 色 → Int32 変換
  - embeds 10件ごとにチャンク送信、title 256 / description 4096 / content 2000 文字で切り詰め
  - メンションは embed 内で機能しないため `content` に `<@ID>` を出力
- `src/discord/repository.cr`: `Discord::PostRepository < Notify::Poster`
  - 429 等の失敗時は例外にして既読化を止める（既存の「送信失敗時は既読化しない」挙動を維持）

### Slack アダプタ化 / usecase の依存除去
- `src/slack/*`: `Notify::Poster` を実装し `Message → Attachment` 変換を内包
- `src/github/usecase.cr`: `to_slack_attachment` → `build_message`（Slack 依存を除去）
- `src/error/usecase.cr` / `src/notify/usecase.cr`: `Notify::Poster` 経由に変更

### エントリポイントと設定
- `src/main.cr`: `NOTIFY_MODE` 分岐でアダプタ生成
- 環境変数: `NOTIFY_MODE` 追加、メンション先を `MENTION_ID` に一般化（未設定時は `SLACK_ID` フォールバック）
- `README.md` 更新

### テスト
- `spec/discord/models_spec.cr` 追加（色変換・チャンク・切り詰め境界・シリアライズ）
- `spec/slack/models_spec.cr` 更新（Message → Attachment 変換・メンション付与）
- `crystal spec` green（25 examples, 0 failures）/ `ameba` clean / `crystal build` OK

## 残作業（デプロイ環境側）

- env.yml に `NOTIFY_MODE=discord` / Discord webhook / Discord ユーザーID を設定して移行
- dev ステージで Discord 通知・メンション・Alert の到達確認

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)