### PR TITLE
fix: Discord 分割送信の途中失敗時の重複投稿を防ぐ (#94)

### DIFF
--- a/spec/github/models_spec.cr
+++ b/spec/github/models_spec.cr
@@ -77,6 +77,7 @@ describe Github::Notification do
     notification.subject.title.should eq "Spurious failure"
     notification.repository.full_name.should eq "octocat/Hello-World"
     notification.mention?.should be_true
+    notification.updated_at.should eq Time.utc(2026, 7, 14, 0, 0, 0)
   end
 end
 
@@ -85,6 +86,7 @@ private def notification_from(reason : String)
     reason:     reason,
     subject:    {type: "Issue", title: "title"},
     repository: {owner: {login: "octocat"}},
+    updated_at: "2026-07-14T00:00:00Z",
   }.to_json)
 end
 
@@ -98,6 +100,7 @@ NOTIFICATIONS_FIXTURE = <<-JSON
       "latest_comment_url": "https://api.github.com/repos/octocat/Hello-World/issues/comments/1",
       "type": "Issue"
     },
+    "updated_at": "2026-07-14T00:00:00Z",
     "repository": {
       "full_name": "octocat/Hello-World",
       "html_url": "https://github.com/octocat/Hello-World",

--- a/spec/notify/usecase_spec.cr
+++ b/spec/notify/usecase_spec.cr
@@ -1,0 +1,102 @@
+require "../spec_helper"
+require "../../src/github/repository"
+require "../../src/github/usecase"
+require "../../src/notify/repository"
+require "../../src/notify/usecase"
+
+# updated_at だけを差し替えられる通知を組み立てる。
+private def notif(updated_at : String, reason = "subscribed")
+  Github::Notification.from_json({
+    reason:     reason,
+    subject:    {type: "Issue", title: "title"},
+    repository: {owner: {login: "octocat"}},
+    updated_at: updated_at,
+  }.to_json)
+end
+
+private def t(sec : Int32)
+  Time.utc(2026, 1, 1, 0, 0, sec)
+end
+
+# HTTP を張らずに済むよう find_* を差し替え、既読化呼び出しを記録するリポジトリ。
+private class FakeNotificationRepo < Github::NotificationRepository
+  getter read_calls = [] of Time?
+
+  def initialize(@notifications : Array(Github::Notification))
+    super("token")
+  end
+
+  def find_notifications_unread : Array(Github::Notification)
+    @notifications
+  end
+
+  def find_comment_by_url(url : String) : Github::Comment
+    Github::Comment.new "body"
+  end
+
+  def notification_to_read(last_read_at : Time? = nil)
+    @read_calls << last_read_at
+  end
+end
+
+# chunk_sizes で指定した件数ごとに送信成功を模し、累計件数を yield する。
+# fail_at 番目（0 始まり）のチャンク送信で例外を投げて途中失敗を再現する。
+private class ChunkPoster < Notify::PostRepository
+  def initialize(@chunk_sizes : Array(Int32), @fail_at : Int32? = nil)
+  end
+
+  def send_messages(messages : Array(Notify::Message), & : Int32 ->)
+    sent = 0
+    @chunk_sizes.each_with_index do |size, i|
+      raise "send failed" if @fail_at == i
+      sent += size
+      yield sent
+    end
+  end
+end
+
+private def run(notifications, poster, &)
+  repo = FakeNotificationRepo.new notifications
+  usecase = Notify::Usecase.new repo, Github::Usecase.new(repo), poster
+  yield usecase
+  repo.read_calls
+end
+
+describe Notify::Usecase do
+  describe "#check_notifications" do
+    it "全チャンク送信成功時は最後に最大 updated_at まで既読化する" do
+      notifications = [notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:02Z"), notif("2026-01-01T00:00:03Z")]
+      read_calls = run(notifications, ChunkPoster.new([1, 1, 1])) do |usecase|
+        usecase.check_notifications
+      end
+      read_calls.should eq [t(1), t(2), t(3)]
+    end
+
+    it "途中失敗時は送信済みチャンクまでしか既読化しない" do
+      notifications = [notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:02Z"), notif("2026-01-01T00:00:03Z")]
+      read_calls = run(notifications, ChunkPoster.new([1, 1, 1], fail_at: 2)) do |usecase|
+        expect_raises(Exception, "send failed") { usecase.check_notifications }
+      end
+      # 03 は未送信のまま。既読化は 02 まで（次回に 03 だけ再取得され重複しない）。
+      read_calls.should eq [t(1), t(2)]
+    end
+
+    it "未送信通知と同一タイムスタンプまで巻き込んで既読化しない" do
+      # 先頭 2 件が同時刻。チャンク境界がその間に落ちても 01 は既読化しない。
+      notifications = [notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:02Z")]
+      read_calls = run(notifications, ChunkPoster.new([1, 1, 1])) do |usecase|
+        usecase.check_notifications
+      end
+      # 1 チャンク目（01 が 1 件のみ送信済み）の直後は、未送信側にも 01 が
+      # 残るため既読化をスキップ。2 チャンク目以降で安全に前進する。
+      read_calls.should eq [t(1), t(2)]
+    end
+
+    it "通知が無ければ既読化しない" do
+      read_calls = run([] of Github::Notification, ChunkPoster.new([] of Int32)) do |usecase|
+        usecase.check_notifications
+      end
+      read_calls.should be_empty
+    end
+  end
+end

--- a/spec/notify/usecase_spec.cr
+++ b/spec/notify/usecase_spec.cr
@@ -22,7 +22,8 @@ end
 private class FakeNotificationRepo < Github::NotificationRepository
   getter read_calls = [] of Time?
 
-  def initialize(@notifications : Array(Github::Notification))
+  # raise_read_after 回目の既読化呼び出しで例外を投げ、既読化失敗を再現する。
+  def initialize(@notifications : Array(Github::Notification), @raise_read_after : Int32? = nil)
     super("token")
   end
 
@@ -36,12 +37,17 @@ private class FakeNotificationRepo < Github::NotificationRepository
 
   def notification_to_read(last_read_at : Time? = nil)
     @read_calls << last_read_at
+    if (limit = @raise_read_after) && @read_calls.size >= limit
+      raise "read failed"
+    end
   end
 end
 
 # chunk_sizes で指定した件数ごとに送信成功を模し、累計件数を yield する。
 # fail_at 番目（0 始まり）のチャンク送信で例外を投げて途中失敗を再現する。
 private class ChunkPoster < Notify::PostRepository
+  getter sent_chunks = 0
+
   def initialize(@chunk_sizes : Array(Int32), @fail_at : Int32? = nil)
   end
 
@@ -50,6 +56,7 @@ private class ChunkPoster < Notify::PostRepository
     @chunk_sizes.each_with_index do |size, i|
       raise "send failed" if @fail_at == i
       sent += size
+      @sent_chunks += 1
       yield sent
     end
   end
@@ -97,6 +104,19 @@ describe Notify::Usecase do
         usecase.check_notifications
       end
       read_calls.should be_empty
+    end
+
+    it "既読化に失敗したら後続チャンクの送信を止める" do
+      notifications = [notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:02Z"), notif("2026-01-01T00:00:03Z")]
+      poster = ChunkPoster.new([1, 1, 1])
+      # 2 回目の既読化で失敗させる。
+      repo = FakeNotificationRepo.new notifications, raise_read_after: 2
+      usecase = Notify::Usecase.new repo, Github::Usecase.new(repo), poster
+
+      expect_raises(Exception, "read failed") { usecase.check_notifications }
+
+      # 2 チャンク送信後の既読化で失敗 → 3 チャンク目は送信されない。
+      poster.sent_chunks.should eq 2
     end
   end
 end

--- a/src/discord/repository.cr
+++ b/src/discord/repository.cr
@@ -15,8 +15,16 @@ module Discord
       @client = HTTP::Client.new @uri
     end
 
-    def send_messages(messages : Array(Notify::Message))
-      Post.build(messages).each { |post| send_post post }
+    def send_messages(messages : Array(Notify::Message), & : Int32 ->)
+      # 通知は複数の webhook 投稿（チャンク）に分割されうる。1 投稿につき
+      # embed は 1 メッセージなので、投稿成功ごとに累計送信件数を yield し、
+      # 呼び出し側が送信済み分だけを既読化できるようにする（issue #94）。
+      sent = 0
+      Post.build(messages).each do |post|
+        send_post post
+        sent += post.embeds.size
+        yield sent
+      end
     end
 
     private def send_post(post : Post)

--- a/src/github/models.cr
+++ b/src/github/models.cr
@@ -19,6 +19,9 @@ module Github
     getter reason : String
     getter repository : Repository
     getter subscription_url : String?
+    # 分割送信時にチャンク単位で既読化するため、通知の更新時刻を保持する。
+    # last_read_at に渡すことで送信済み分だけを既読化できる（issue #94）。
+    getter updated_at : Time
 
     def mention? : Bool
       reason.in?(MENTION_REASONS)

--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -67,8 +67,11 @@ module Github
     # 省略時は現在時刻までの全通知を既読化する。
     def notification_to_read(last_read_at : Time? = nil)
       if last_read_at
+        # JSON ボディを送るため Content-Type を明示する。無いと GitHub 側で
+        # ボディが解析されず last_read_at が無視される恐れがある。
+        headers = HTTP::Headers{"Content-Type" => "application/json"}
         body = {last_read_at: last_read_at.to_utc}.to_json
-        @github.put "/notifications", body: body
+        @github.put "/notifications", headers: headers, body: body
       else
         @github.put "/notifications"
       end

--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -61,8 +61,17 @@ module Github
       end
     end
 
-    def notification_to_read
-      @github.put "/notifications"
+    # 通知を既読化する。last_read_at を渡すと、その時刻以前に更新された通知
+    # だけを既読化する（それ以降に更新された通知は未読のまま残る）。分割送信で
+    # 送信済みチャンクまでを都度既読化し、途中失敗時の重複投稿を防ぐのに使う。
+    # 省略時は現在時刻までの全通知を既読化する。
+    def notification_to_read(last_read_at : Time? = nil)
+      if last_read_at
+        body = {last_read_at: last_read_at.to_utc}.to_json
+        @github.put "/notifications", body: body
+      else
+        @github.put "/notifications"
+      end
     end
   end
 end

--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -5,6 +5,9 @@ require "../runtime/lambda"
 
 module Github
   class NotificationRepository
+    PER_PAGE  = 100 # GitHub /notifications の per_page 上限
+    MAX_PAGES =  20 # 暴走防止の取得ページ数上限（= 最大 2000 件）
+
     def initialize(@token : String)
       uri = URI.parse "https://api.github.com"
       @github = HTTP::Client.new uri
@@ -14,26 +17,51 @@ module Github
       end
     end
 
+    # 未読通知を全ページ取得する。
+    #
+    # /notifications はページングされ既定では 1 ページ分（最新側）しか返さない。
+    # 一部ページだけを取得した状態で last_read_at 既読化を行うと、未取得の
+    # 古い通知（＝更新時刻が小さくチャンク送信対象外）まで last_read_at 以前と
+    # して既読化され、未送信のまま消えてしまう。これを防ぐため全ページを
+    # 取得してから境界を決める必要がある（issue #94 / PR #97 レビュー指摘）。
+    #
+    # 途中ページで一時的な失敗（5xx / 401）が起きた場合は、取得済みが不完全な
+    # まま既読化して取りこぼすのを避けるため、その実行は丸ごとスキップして
+    # 次回に委ねる。
     def find_notifications_unread : Array(Notification)
-      res = @github.get "/notifications"
-      if res.status.server_error?
-        Serverless::Lambda.print_log "return 5xx error from notifications api"
-        return [] of Notification
-      elsif res.status.unauthorized?
-        # GitHub が断続的に 401 を返すことがあるため、毎分の次回実行に任せてスキップする。
-        # トークン失効などの恒久的な 401 までサイレントに握りつぶす点は本来リトライや
-        # 連続失敗の監視で区別すべきだが、個人用途の通知ツールであり実装コストに
-        # 見合わないため割り切る。
-        Serverless::Lambda.print_log "return 401 error from notifications api, skip"
-        return [] of Notification
-      elsif res.status.client_error?
-        Serverless::Lambda.print_log "return 4xx error from notifications api"
-        err = Error.from_json res.body
-        raise "notifications api return client error: #{err.message}"
+      notifications = [] of Notification
+
+      (1..MAX_PAGES).each do |page|
+        res = @github.get "/notifications?per_page=#{PER_PAGE}&page=#{page}"
+        if res.status.server_error?
+          Serverless::Lambda.print_log "return 5xx error from notifications api"
+          return [] of Notification
+        elsif res.status.unauthorized?
+          # GitHub が断続的に 401 を返すことがあるため、毎分の次回実行に任せてスキップする。
+          # トークン失効などの恒久的な 401 までサイレントに握りつぶす点は本来リトライや
+          # 連続失敗の監視で区別すべきだが、個人用途の通知ツールであり実装コストに
+          # 見合わないため割り切る。
+          Serverless::Lambda.print_log "return 401 error from notifications api, skip"
+          return [] of Notification
+        elsif res.status.client_error?
+          Serverless::Lambda.print_log "return 4xx error from notifications api"
+          err = Error.from_json res.body
+          raise "notifications api return client error: #{err.message}"
+        end
+
+        Serverless::Lambda.print_log "notifications body (page #{page}): #{res.body}"
+        page_items = Array(Notification).from_json(res.body)
+        notifications.concat page_items
+
+        # 最終ページ（取得件数が上限未満）に達したら終了。
+        break if page_items.size < PER_PAGE
+
+        if page == MAX_PAGES
+          Serverless::Lambda.print_log "reached MAX_PAGES(#{MAX_PAGES}); remaining older notifications are deferred to next run"
+        end
       end
 
-      Serverless::Lambda.print_log "notifications body: #{res.body}"
-      Array(Notification).from_json(res.body)
+      notifications
     end
 
     def find_comment_by_url(url : String) : Comment

--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -25,14 +25,25 @@ module Github
     # して既読化され、未送信のまま消えてしまう。これを防ぐため全ページを
     # 取得してから境界を決める必要がある（issue #94 / PR #97 レビュー指摘）。
     #
-    # 途中ページで一時的な失敗（5xx / 401）が起きた場合は、取得済みが不完全な
-    # まま既読化して取りこぼすのを避けるため、その実行は丸ごとスキップして
-    # 次回に委ねる。
+    # ページング中に新着通知が入るとオフセットがずれ前ページ末尾の取りこぼしが
+    # 起きるため、取得開始時刻を上限（before）に固定してページ集合を安定させる。
+    # 上限より新しい通知は取得対象から外れるが、次回実行で取得される。
+    #
+    # 取得しきれない場合（途中ページの一時失敗 5xx/401、またはページ数上限到達）は、
+    # 不完全な取得状態で既読化して取りこぼすのを避けるため、その実行を丸ごと
+    # スキップして次回に委ねる。
     def find_notifications_unread : Array(Notification)
       notifications = [] of Notification
+      before = Time.utc
+      complete = false
 
       (1..MAX_PAGES).each do |page|
-        res = @github.get "/notifications?per_page=#{PER_PAGE}&page=#{page}"
+        params = URI::Params.build do |form|
+          form.add "per_page", PER_PAGE.to_s
+          form.add "page", page.to_s
+          form.add "before", before.to_rfc3339
+        end
+        res = @github.get "/notifications?#{params}"
         if res.status.server_error?
           Serverless::Lambda.print_log "return 5xx error from notifications api"
           return [] of Notification
@@ -53,12 +64,18 @@ module Github
         page_items = Array(Notification).from_json(res.body)
         notifications.concat page_items
 
-        # 最終ページ（取得件数が上限未満）に達したら終了。
-        break if page_items.size < PER_PAGE
-
-        if page == MAX_PAGES
-          Serverless::Lambda.print_log "reached MAX_PAGES(#{MAX_PAGES}); remaining older notifications are deferred to next run"
+        # 最終ページ（取得件数が上限未満）に達したら取得完了。
+        if page_items.size < PER_PAGE
+          complete = true
+          break
         end
+      end
+
+      # 全ページを取得しきる前に上限に達した場合、未取得の古い通知を
+      # last_read_at で巻き込み既読化しないよう、この実行はスキップする。
+      unless complete
+        Serverless::Lambda.print_log "reached MAX_PAGES(#{MAX_PAGES}) without exhausting notifications; skip this run to avoid marking unfetched older notifications as read"
+        return [] of Notification
       end
 
       notifications
@@ -94,14 +111,23 @@ module Github
     # 送信済みチャンクまでを都度既読化し、途中失敗時の重複投稿を防ぐのに使う。
     # 省略時は現在時刻までの全通知を既読化する。
     def notification_to_read(last_read_at : Time? = nil)
-      if last_read_at
-        # JSON ボディを送るため Content-Type を明示する。無いと GitHub 側で
-        # ボディが解析されず last_read_at が無視される恐れがある。
-        headers = HTTP::Headers{"Content-Type" => "application/json"}
-        body = {last_read_at: last_read_at.to_utc}.to_json
-        @github.put "/notifications", headers: headers, body: body
-      else
-        @github.put "/notifications"
+      res =
+        if last_read_at
+          # JSON ボディを送るため Content-Type を明示する。無いと GitHub 側で
+          # ボディが解析されず last_read_at が無視される恐れがある。
+          headers = HTTP::Headers{"Content-Type" => "application/json"}
+          body = {last_read_at: last_read_at.to_utc}.to_json
+          @github.put "/notifications", headers: headers, body: body
+        else
+          @github.put "/notifications"
+        end
+
+      # 分割送信の重複防止は「送信済みチャンクまでが既読化されている」ことに
+      # 依存する。既読化が失敗したまま後続チャンクの送信を続けると、送信済み
+      # なのに未既読のチャンクができ、その後の送信失敗時にそれだけが次回重複
+      # 投稿される。失敗時は例外にして送信を止め、次回実行に委ねる。
+      unless res.success?
+        raise "notifications read api returned #{res.status_code}: #{res.body}"
       end
     end
   end

--- a/src/notify/repository.cr
+++ b/src/notify/repository.cr
@@ -4,7 +4,17 @@ module Notify
   # 通知の送信先を抽象化するインターフェース。
   # Slack::PostRepository / Discord::PostRepository が実装する。
   abstract class PostRepository
-    abstract def send_messages(messages : Array(Message))
+    # メッセージを送信先の投稿単位（チャンク）ごとに送る。
+    # 1 チャンクの送信に成功するたび、そこまでに送信済みのメッセージ件数
+    # （累計）を yield する。呼び出し側はこれを使って送信済み分だけを都度
+    # 既読化でき、分割送信の途中失敗時に前半チャンクが重複投稿されるのを防ぐ
+    # （issue #94）。Slack は全メッセージを 1 投稿で送るため atomic で、
+    # 送信後に一度だけ全件を yield する。
+    abstract def send_messages(messages : Array(Message), & : Int32 ->)
+
+    def send_messages(messages : Array(Message))
+      send_messages(messages) { }
+    end
 
     def send_message(message : Message)
       send_messages [message]

--- a/src/notify/usecase.cr
+++ b/src/notify/usecase.cr
@@ -51,6 +51,9 @@ module Notify
     private def mark_read_through(notifications : Array(Github::Notification), sent_count : Int32)
       return if sent_count <= 0
 
+      # sent_count は poster 実装（外部境界）から渡るため、通知件数で丸めて
+      # 想定外の値でも安全にスライスできるようにする。
+      sent_count = {sent_count, notifications.size}.min
       sent = notifications[0, sent_count]
       next_unsent = notifications[sent_count]?
 

--- a/src/notify/usecase.cr
+++ b/src/notify/usecase.cr
@@ -12,26 +12,59 @@ module Notify
     end
 
     def check_notifications
-      notices = @github_repo
+      # updated_at 昇順にソートしてから送信することで、送信済み分を
+      # last_read_at で都度既読化できるようにする（issue #94）。
+      notifications = @github_repo
         .find_notifications_unread
-        .map do |item|
-          message =
-            if item.subject.update?
-              "更新があったみたいです。確認してみましょう！"
-            else
-              "なにかあったみたいです。確認してみましょう！"
-            end
-          pretext = "[#{item.subject.type}] #{message}"
+        .sort_by(&.updated_at)
 
-          @github_uc.build_message item, pretext
-        end
+      return {msg: "ok"} if notifications.empty?
 
-      unless notices.empty?
-        @poster.send_messages notices
-        @github_repo.notification_to_read
+      notices = notifications.map do |item|
+        message =
+          if item.subject.update?
+            "更新があったみたいです。確認してみましょう！"
+          else
+            "なにかあったみたいです。確認してみましょう！"
+          end
+        pretext = "[#{item.subject.type}] #{message}"
+
+        @github_uc.build_message item, pretext
+      end
+
+      # チャンク送信が成功するたび、そこまでに送信済みの通知だけを既読化する。
+      # 途中で失敗しても送信済み分は既読化済みなので、未送信分だけが次回
+      # 再取得され、前半チャンクの重複投稿が起きない。
+      @poster.send_messages(notices) do |sent_count|
+        mark_read_through notifications, sent_count
       end
 
       {msg: "ok"}
+    end
+
+    # 昇順ソート済み notifications の先頭 sent_count 件（＝送信済み）までを既読化する。
+    # last_read_at は「未送信の先頭通知より前の最大 updated_at」に丸める。これにより
+    # 未送信通知と同一タイムスタンプの通知まで巻き込んで既読化してしまうのを防ぐ
+    # （PUT /notifications は last_read_at 以前に更新された通知を既読化するため）。
+    # 送信済みが全て未送信先頭と同時刻の場合は安全に進められる位置が無いのでスキップし、
+    # 次回実行に委ねる（稀な重複より通知ロストを避ける）。
+    private def mark_read_through(notifications : Array(Github::Notification), sent_count : Int32)
+      return if sent_count <= 0
+
+      sent = notifications[0, sent_count]
+      next_unsent = notifications[sent_count]?
+
+      last_read_at =
+        if next_unsent.nil?
+          sent.last.updated_at
+        else
+          boundary = next_unsent.updated_at
+          sent.map(&.updated_at).select(&.<(boundary)).max?
+        end
+
+      return if last_read_at.nil?
+
+      @github_repo.notification_to_read last_read_at
     end
   end
 end

--- a/src/slack/repository.cr
+++ b/src/slack/repository.cr
@@ -12,8 +12,11 @@ module Slack
       @client = HTTP::Client.new @uri
     end
 
-    def send_messages(messages : Array(Notify::Message))
+    def send_messages(messages : Array(Notify::Message), & : Int32 ->)
+      # Slack は全 attachments を 1 投稿で送るため atomic。送信成功後に
+      # 全件をまとめて既読化できるよう、累計件数を一度だけ yield する。
       send_post Post.build(messages)
+      yield messages.size
     end
 
     private def send_post(post : Post)


### PR DESCRIPTION
## 概要

issue #94 を解決する。Discord モードで通知が複数の webhook 投稿に分割される際、分割送信の途中で失敗すると前半チャンクが送信済みなのに既読化されず、次回実行で重複投稿されうる問題を修正する。

issue で検討された **チャンク単位の `last_read_at` 付き一括既読化** を採用した（スレッド単位既読化の N+1 懸念を避けつつ、既読化コールを送信コールと同数に抑えられる案）。

## 変更内容

1. **通知を `updated_at` 昇順にソートしてから送信** (`Notify::Usecase`)
2. **各チャンクの送信成功ごとに送信済み分だけを既読化**
   - `Notify::PostRepository#send_messages` を、チャンク送信成功ごとに累計送信件数を `yield` するブロック付き I/F に変更
     - Slack: 全 attachments を 1 投稿で送る atomic 実装のため、送信後に一度だけ全件を yield
     - Discord: webhook 投稿（チャンク）ごとに累計件数を yield
   - `Notify::Usecase` が yield された件数から `last_read_at` を算出し `PUT /notifications` を都度呼ぶ
3. **`GitHub::NotificationRepository#notification_to_read` に `last_read_at` パラメータを追加**
   - 指定時刻以前に更新された通知だけを既読化する
4. **`Github::Notification` に `updated_at` を追加**

## 途中失敗時の挙動

チャンク送信が途中で失敗しても、送信済みチャンクまでは `last_read_at` で既読化済みのため、未送信分だけが次回実行で再取得される。前半チャンクの重複投稿が原理的に発生しない。

## 同一タイムスタンプの境界考慮

issue の注意点どおり、未送信の先頭通知と同一 `updated_at` の通知まで巻き込んで既読化しないよう、`last_read_at` を「未送信先頭より前の最大 `updated_at`」に丸めている。安全に前進できる位置が無い（送信済みが全て未送信先頭と同時刻）稀なケースはスキップし、次回実行に委ねる（通知ロストより稀な重複を許容）。

## 副次効果

現行のパラメータなし `PUT /notifications`（現在時刻までの全既読化）にあった「fetch 後〜既読化までに届いた新規通知を通知せず既読化する窓」も、`last_read_at` 方式により狭まる。

## テスト

- `spec/notify/usecase_spec.cr` を新規追加し、全チャンク成功 / 途中失敗 / 同一タイムスタンプ境界 / 通知ゼロ件の既読化挙動を検証
- `crystal spec` 31 examples 0 failures / `ameba` 0 failures / `crystal build src/main.cr` 成功

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)