### PR TITLE
fix: Discord でbotのセリフを content に表示する (#95)

### DIFF
--- a/spec/discord/models_spec.cr
+++ b/spec/discord/models_spec.cr
@@ -15,11 +15,17 @@ describe Discord::Embed do
   end
 
   describe ".from_message" do
-    it "merges pretext and text into the description" do
+    it "uses only the comment body as the description (pretext goes to content)" do
       message = Notify::Message.new(pretext: "pre", text: "body")
       embed = Discord::Embed.from_message(message)
 
-      embed.description.should eq "pre\n\nbody"
+      embed.description.should eq "body"
+    end
+
+    it "leaves description unset when there is no comment body" do
+      embed = Discord::Embed.from_message(Notify::Message.new(pretext: "pre"))
+
+      embed.description.should be_nil
     end
 
     it "drops author and footer when their required fields are absent" do
@@ -133,6 +139,39 @@ describe Discord::Post do
       posts = Discord::Post.build([Notify::Message.new(title: "a")])
 
       posts[0].content.should be_nil
+    end
+
+    it "outputs the bot serif (pretext) as content" do
+      posts = Discord::Post.build([Notify::Message.new(title: "a", pretext: "[Issue] hi")])
+
+      posts[0].content.should eq "[Issue] hi"
+    end
+
+    it "prepends the channel-wide mention before the serif" do
+      posts = Discord::Post.build([Notify::Message.new(title: "a", pretext: "[Issue] hi", mention: true)])
+
+      posts[0].content.should eq "@everyone\n[Issue] hi"
+    end
+
+    it "de-duplicates repeated serifs within a chunk while keeping order" do
+      messages = [
+        Notify::Message.new(title: "a", pretext: "[Issue] hi"),
+        Notify::Message.new(title: "b", pretext: "[Issue] hi"),
+        Notify::Message.new(title: "c", pretext: "[PullRequest] yo"),
+      ]
+      posts = Discord::Post.build(messages)
+
+      posts.size.should eq 1
+      posts[0].content.should eq "[Issue] hi\n[PullRequest] yo"
+    end
+
+    it "truncates content to the Discord content limit" do
+      # 各セリフを異なる内容にして uniq でまとまらないようにする。
+      messages = Array.new(3) { |i| Notify::Message.new(title: "t#{i}", pretext: "#{i}#{"p" * 900}") }
+      posts = Discord::Post.build(messages)
+
+      posts.size.should eq 1
+      posts[0].content.as(String).size.should eq Discord::CONTENT_LIMIT
     end
 
     it "serializes embeds under an embeds key" do

--- a/src/discord/models.cr
+++ b/src/discord/models.cr
@@ -31,13 +31,15 @@ module Discord
     def self.build(messages : Array(Notify::Message)) : Array(Post)
       posts = [] of Post
       chunk = [] of Embed
+      pretexts = [] of String
       chunk_chars = 0
       mention = false
 
       flush = -> do
         return if chunk.empty?
-        posts << Post.new(chunk, mention_content(mention))
+        posts << Post.new(chunk, build_content(pretexts, mention))
         chunk = [] of Embed
+        pretexts = [] of String
         chunk_chars = 0
         mention = false
       end
@@ -50,6 +52,9 @@ module Discord
         end
         chunk << embed
         chunk_chars += size
+        if pretext = message.pretext.try(&.presence)
+          pretexts << pretext
+        end
         mention = true if message.mention?
       end
       flush.call
@@ -57,9 +62,17 @@ module Discord
       posts
     end
 
-    # メンションは embed 内では機能しないため content に出力する。
-    private def self.mention_content(mention : Bool) : String?
-      EVERYONE_MENTION if mention
+    # botのセリフ（pretext）を content に出力する。embed には pretext 相当の欄が
+    # 無いため、Slack と同様に「botの発言行」として embed の外（content）へ出す
+    # （issue #95）。メンションは embed 内では機能しないため content 先頭に
+    # @everyone を添える。チャンク内で重複するセリフは uniq でまとめ、content は
+    # 2000 文字上限があるため truncate する。
+    private def self.build_content(pretexts : Array(String), mention : Bool) : String?
+      lines = [] of String
+      lines << EVERYONE_MENTION if mention
+      lines.concat pretexts.uniq
+      return nil if lines.empty?
+      Discord.truncate(lines.join("\n"), CONTENT_LIMIT)
     end
   end
 
@@ -92,12 +105,9 @@ module Discord
     end
 
     def self.from_message(message : Notify::Message) : Embed
-      # Slack の pretext 相当の欄が embed には無いため text とまとめて description にする。
-      description = [message.pretext, message.text]
-        .compact
-        .reject(&.empty?)
-        .join("\n\n")
-        .presence
+      # pretext（botのセリフ）は Post の content 側に出すため、description には
+      # 含めずコメント本文のみとする（二重表示を避ける / issue #95）。
+      description = message.text.try(&.presence)
 
       Embed.new(
         title: message.title.try { |value| Discord.truncate(value, TITLE_LIMIT) },

--- a/src/discord/repository.cr
+++ b/src/discord/repository.cr
@@ -4,6 +4,7 @@ require "http/client"
 require "./models"
 require "../notify/models"
 require "../notify/repository"
+require "../runtime/lambda"
 
 module Discord
   class PostRepository < Notify::PostRepository
@@ -29,6 +30,9 @@ module Discord
 
     private def send_post(post : Post)
       body = post.to_json
+      # 送信ペイロードを記録し、content（セリフ）や description / footer が意図通りか
+      # CloudWatch で確認できるようにする（issue #95 の切り分け用）。
+      Serverless::Lambda.print_log "discord payload: #{body}"
       headers = HTTP::Headers{"Content-Type" => "application/json"}
 
       attempt = 0


### PR DESCRIPTION
## 概要

issue #95 を解決する。Discord 投稿時に botのセリフ（`[Issue] 更新があったみたいです。確認してみましょう！` 等の pretext）が「消えている」ように見える問題を修正する。

## 原因

- Slack モードではセリフ（pretext）は attachment の `pretext` として **カードの外＝botの発言行** に表示される。
- Discord モードでは embed に pretext 相当の欄が無いため、セリフを embed の `description`（コメント本文）に結合して入れていた。つまりセリフは **embed カードの中** にしか出ず、botの発言として表示されない。
- さらにメンション時の `content`（botの発言行）は `@everyone` のみを出力しており、`MENTION_REASONS` が広く実通知はほぼメンション扱いとなるため、**発言行には `@everyone` しか出ずセリフが消えたように見えていた**。

## 修正内容 (`src/discord/models.cr`)

1. **セリフ（pretext）を Post の `content` に出力** し、Slack と同様「botの発言行」として embed の外に表示する
   - メンション時は `content` 先頭に `@everyone` を添える（`@everyone\n<セリフ>`）
   - 1投稿に複数 embed をまとめる場合、チャンク内の pretext を `uniq`（順序保持）して結合
   - `content` の 2000 文字上限（`CONTENT_LIMIT`）で truncate
2. **二重表示を避けるため `description` からは pretext を外し**、コメント本文のみとする
3. 送信ペイロード（`Post#to_json`）を `print_log` で出力し、表示の切り分け（description / footer が意図通りか）を CloudWatch で確認できるようにする

## 表示イメージ（実ペイロード）

```json
{"content":"@everyone\n[Issue] 更新があったみたいです。確認してみましょう！","embeds":[{"title":"Spurious failure","description":"コメント本文です","color":11129077,"footer":{"text":"octocat/Hello-World"}},{"title":"Another","description":"別コメント"}]}
```

セリフが `content`（botの発言行）に出て、embed の `description` はコメント本文のみになった。同一チャンク内の同じセリフは1行にまとめられる。

## フッターについて

Discord embed の `footer.text` は仕様上プレーンテキストのみ（リンク・markdown 不可）で、現実装もリポジトリ名を文字列として送っており、そもそもリンクは設定していない。表示欠落は Discord クライアント側の描画の可能性があり、実害があれば別 issue に切り出す方針（本 PR のスコープ外）。

## テスト

- `spec/discord/models_spec.cr` を更新（content へのセリフ出力 / mention 併記 / description から pretext 除外 / uniq / truncate）
- `crystal spec` 37 examples 0 failures / `ameba` 0 failures / `crystal build src/main.cr` 成功

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)