### PR TITLE
fix: 通知内容の見直し・改善 (#96)

### DIFF
--- a/spec/github/models_spec.cr
+++ b/spec/github/models_spec.cr
@@ -51,6 +51,20 @@ describe Github::Subject do
       subject.comment_url.should eq "u"
     end
   end
+
+  describe "#number" do
+    it "extracts a trailing issue/PR number from the url" do
+      subject_from("Issue", url: "https://api.github.com/repos/o/r/issues/42").number.should eq "42"
+    end
+
+    it "returns nil when the trailing segment is not numeric (e.g. a commit SHA)" do
+      subject_from("Commit", url: "https://api.github.com/repos/o/r/commits/abc123").number.should be_nil
+    end
+
+    it "returns nil when the url is blank" do
+      subject_from("Issue").number.should be_nil
+    end
+  end
 end
 
 describe Github::Notification do
@@ -64,6 +78,48 @@ describe Github::Notification do
     it "is false for non-mention reasons" do
       notification_from("subscribed").mention?.should be_false
       notification_from("ci_activity").mention?.should be_false
+    end
+  end
+
+  describe "#reason_message" do
+    it "returns a reason-specific message for known reasons" do
+      notification_from("review_requested").reason_message.should eq "レビューを依頼されました"
+      notification_from("assign").reason_message.should eq "アサインされました"
+      notification_from("comment").reason_message.should eq "コメントがつきました"
+    end
+
+    it "falls back to a generic message for unknown reasons" do
+      notification_from("some_future_reason").reason_message.should eq Github::Notification::GENERIC_MESSAGE
+    end
+  end
+
+  describe "#pretext" do
+    it "prefixes the subject type before the reason message" do
+      notification_from("mention").pretext.should eq "[Issue] メンションされました"
+    end
+  end
+
+  describe "#display_title" do
+    it "formats as owner/repo#number title when a number is present" do
+      notification = notification_with(url: "https://api.github.com/repos/octocat/Hello-World/issues/42")
+      notification.display_title.should eq "octocat/Hello-World#42 title"
+    end
+
+    it "falls back to the bare title when no number is present" do
+      notification_with(url: "").display_title.should eq "title"
+    end
+  end
+
+  describe "#link" do
+    it "prefers the comment html_url" do
+      comment = Github::Comment.from_json({html_url: "https://example.com/c", user: {} of String => String}.to_json)
+      notification_with.link(comment).should eq "https://example.com/c"
+    end
+
+    it "falls back to the repository html_url when the comment has no link" do
+      comment = Github::Comment.new nil
+      notification = notification_with(repo_html_url: "https://github.com/octocat/Hello-World")
+      notification.link(comment).should eq "https://github.com/octocat/Hello-World"
     end
   end
 
@@ -86,6 +142,15 @@ private def notification_from(reason : String)
     reason:     reason,
     subject:    {type: "Issue", title: "title"},
     repository: {owner: {login: "octocat"}},
+    updated_at: "2026-07-14T00:00:00Z",
+  }.to_json)
+end
+
+private def notification_with(url = "", repo_html_url : String? = nil)
+  Github::Notification.from_json({
+    reason:     "subscribed",
+    subject:    {type: "Issue", title: "title", url: url},
+    repository: {full_name: "octocat/Hello-World", html_url: repo_html_url, owner: {login: "octocat"}},
     updated_at: "2026-07-14T00:00:00Z",
   }.to_json)
 end

--- a/spec/github/models_spec.cr
+++ b/spec/github/models_spec.cr
@@ -46,9 +46,18 @@ describe Github::Subject do
       subject.comment_url.should eq "c"
     end
 
-    it "falls back to url when latest_comment_url is blank" do
+    it "falls back to url for body-bearing types when latest_comment_url is blank" do
       subject = subject_from("Issue", url: "u", latest_comment_url: "")
       subject.comment_url.should eq "u"
+    end
+
+    it "returns empty for types without a comment body when no comment url is present" do
+      # CI 完了通知（CheckSuite）などは subject.url を本文取得に使わない
+      subject_from("CheckSuite", url: "https://api.github.com/repos/o/r/check-suites/1").comment_url.should eq ""
+    end
+
+    it "still uses latest_comment_url even for non-body types" do
+      subject_from("Commit", url: "u", latest_comment_url: "c").comment_url.should eq "c"
     end
   end
 
@@ -57,8 +66,17 @@ describe Github::Subject do
       subject_from("Issue", url: "https://api.github.com/repos/o/r/issues/42").number.should eq "42"
     end
 
+    it "tolerates a trailing slash" do
+      subject_from("Issue", url: "https://api.github.com/repos/o/r/issues/42/").number.should eq "42"
+    end
+
     it "returns nil when the trailing segment is not numeric (e.g. a commit SHA)" do
       subject_from("Commit", url: "https://api.github.com/repos/o/r/commits/abc123").number.should be_nil
+    end
+
+    it "returns nil for types whose trailing number is not a GitHub issue/PR number" do
+      # Release は末尾が数値 ID でも #番号 表示は誤解を招くため付けない
+      subject_from("Release", url: "https://api.github.com/repos/o/r/releases/5").number.should be_nil
     end
 
     it "returns nil when the url is blank" do

--- a/spec/github/usecase_spec.cr
+++ b/spec/github/usecase_spec.cr
@@ -1,0 +1,70 @@
+require "../spec_helper"
+require "../../src/github/repository"
+require "../../src/github/usecase"
+
+# HTTP を張らずに、あらかじめ用意した Comment を返すリポジトリ。
+private class StubRepo < Github::NotificationRepository
+  def initialize(@comment : Github::Comment)
+    super("token")
+  end
+
+  def find_comment_by_url(url : String) : Github::Comment
+    @comment
+  end
+end
+
+private def notification(
+  url = "https://api.github.com/repos/octocat/Hello-World/issues/42",
+  reason = "review_requested",
+  repo_html_url : String? = "https://github.com/octocat/Hello-World",
+)
+  Github::Notification.from_json({
+    reason:     reason,
+    subject:    {type: "Issue", title: "Spurious failure", url: url},
+    repository: {full_name: "octocat/Hello-World", html_url: repo_html_url, owner: {login: "octocat"}},
+    updated_at: "2026-07-14T00:00:00Z",
+  }.to_json)
+end
+
+private def comment(body : String? = "body", html_url : String? = "https://example.com/c")
+  Github::Comment.from_json({body: body, html_url: html_url, user: {login: "octocat"}}.to_json)
+end
+
+private def build(notify, comment)
+  Github::Usecase.new(StubRepo.new(comment)).build_message(notify)
+end
+
+describe Github::Usecase do
+  describe "#build_message" do
+    it "reflects the reason in the pretext" do
+      build(notification(reason: "review_requested"), comment).pretext.should eq "[Issue] レビューを依頼されました"
+    end
+
+    it "formats the title as owner/repo#number title" do
+      build(notification, comment).title.should eq "octocat/Hello-World#42 Spurious failure"
+    end
+
+    it "uses the comment html_url as the title link" do
+      build(notification, comment(html_url: "https://example.com/c")).title_link.should eq "https://example.com/c"
+    end
+
+    it "falls back to the repository html_url when the comment has no link" do
+      message = build(notification(repo_html_url: "https://github.com/octocat/Hello-World"), comment(html_url: nil))
+      message.title_link.should eq "https://github.com/octocat/Hello-World"
+    end
+
+    it "truncates a long comment body to the limit with an ellipsis" do
+      message = build(notification, comment(body: "a" * 600))
+      message.text.as(String).size.should eq Github::Usecase::BODY_LIMIT + 1
+      message.text.as(String).should end_with "…"
+    end
+
+    it "keeps a short comment body unchanged" do
+      build(notification, comment(body: "short")).text.should eq "short"
+    end
+
+    it "leaves text nil when there is no comment body" do
+      build(notification, comment(body: nil)).text.should be_nil
+    end
+  end
+end

--- a/src/github/models.cr
+++ b/src/github/models.cr
@@ -96,6 +96,22 @@ module Github
       Type::DISCUSSION,
     }
 
+    # subject.url 末尾が GitHub 上の番号として意味を持つ type。Release / CheckSuite
+    # のように末尾が数値 ID でも #番号 表示は誤解を招くため、これらに限定する。
+    NUMBERED_TYPES = {
+      Type::PULL_REQUEST,
+      Type::ISSUE,
+      Type::DISCUSSION,
+    }
+
+    # subject.url / latest_comment_url を取得すると本文（body）付きのオブジェクトが
+    # 返る type。Commit / CheckSuite 等は body が無くコメントとして解釈できないため、
+    # コメント URL が無ければ本文取得の対象にしない（CI 完了通知等に本文を付けない）。
+    BODY_TYPES = {
+      Type::PULL_REQUEST,
+      Type::ISSUE,
+    }
+
     def update? : Bool
       type.in?(UPDATE_TYPES)
     end
@@ -115,14 +131,20 @@ module Github
       end
     end
 
+    # 本文取得に使う URL。コメントがあればその URL、無ければ本文を持つ type に
+    # 限り subject.url にフォールバックする。対象外（CI 等）は空文字を返し、
+    # 呼び出し側で本文なし扱いにする（issue #96）。
     def comment_url : String
-      latest_comment_url.presence || url
+      return latest_comment_url if latest_comment_url.presence
+      type.in?(BODY_TYPES) ? url : ""
     end
 
-    # subject.url 末尾の PR / Issue / Discussion 番号。Commit（末尾が SHA）や
-    # URL が無い場合など、数値でなければ nil を返す（issue #96）。
+    # subject.url 末尾の PR / Issue / Discussion 番号。番号が意味を持つ type に
+    # 限り、末尾セグメントが数値なら返す。Commit（末尾が SHA）や末尾スラッシュ、
+    # URL が無い場合などは nil を返す（issue #96）。
     def number : String?
-      segment = url.split('/').last?
+      return nil unless type.in?(NUMBERED_TYPES)
+      segment = url.chomp('/').split('/').last?
       segment if segment && segment.matches?(/\A\d+\z/)
     end
   end

--- a/src/github/models.cr
+++ b/src/github/models.cr
@@ -15,6 +15,25 @@ module Github
       # "ci_activity",
     }
 
+    # reason（なぜ自分に通知されたか）ごとの表示文言。update? による
+    # 「更新があったみたいです」一辺倒だと通知理由が伝わらないため、reason を
+    # 文面に反映する（issue #96）。GitHub 側の reason 追加に耐えるよう、
+    # 未知の reason は reason_message で汎用文言にフォールバックする。
+    REASON_MESSAGES = {
+      "mention"          => "メンションされました",
+      "team_mention"     => "メンションされました",
+      "review_requested" => "レビューを依頼されました",
+      "assign"           => "アサインされました",
+      "author"           => "自分の PR/Issue に動きがありました",
+      "comment"          => "コメントがつきました",
+      "state_change"     => "状態が変わりました",
+      "subscribed"       => "ウォッチ中のリポジトリで動きがありました",
+      "ci_activity"      => "CI の実行結果が届きました",
+      "invitation"       => "招待が届きました",
+    }
+
+    GENERIC_MESSAGE = "なにかあったみたいです。確認してみましょう！"
+
     getter subject : Subject
     getter reason : String
     getter repository : Repository
@@ -25,6 +44,33 @@ module Github
 
     def mention? : Bool
       reason.in?(MENTION_REASONS)
+    end
+
+    def reason_message : String
+      REASON_MESSAGES[reason]? || GENERIC_MESSAGE
+    end
+
+    # 通知の pretext（botのセリフ）。`[<type>] <reason 文言>` 形式。
+    def pretext : String
+      "[#{subject.type}] #{reason_message}"
+    end
+
+    # 一目で対象が分かるよう `owner/repo#番号 タイトル` 形式にする。
+    # 番号が取れない（Commit など）場合はタイトルのみ、リポジトリ名が無ければ
+    # 番号のみにフォールバックする（issue #96）。
+    def display_title : String?
+      title = subject.title
+      number = subject.number
+      return title unless number
+
+      prefix = repository.full_name.try { |name| "#{name}##{number}" } || "##{number}"
+      title ? "#{prefix} #{title}" : prefix
+    end
+
+    # 対象へ飛べるリンク。コメントの html_url を優先し、無ければリポジトリの
+    # html_url にフォールバックしてリンク無し通知を無くす（issue #96）。
+    def link(comment : Comment) : String?
+      comment.html_url.try(&.presence) || repository.html_url
     end
   end
 
@@ -71,6 +117,13 @@ module Github
 
     def comment_url : String
       latest_comment_url.presence || url
+    end
+
+    # subject.url 末尾の PR / Issue / Discussion 番号。Commit（末尾が SHA）や
+    # URL が無い場合など、数値でなければ nil を返す（issue #96）。
+    def number : String?
+      segment = url.split('/').last?
+      segment if segment && segment.matches?(/\A\d+\z/)
     end
   end
 

--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -92,7 +92,16 @@ module Github
         return Comment.new nil
       end
 
-      res = @github.get url
+      res =
+        begin
+          @github.get url
+        rescue ex
+          # ネットワークエラー等で 1 件のコメント取得に失敗しても、他の通知の
+          # 送信まで巻き添えにしないよう、例外にせず表示用文言で握りつぶす。
+          Serverless::Lambda.print_log "failed to get comment from api: #{ex.message}"
+          return Comment.new COMMENT_FETCH_FAILED
+        end
+
       if res.status.server_error?
         Serverless::Lambda.print_log "return 5xx error from comments api"
         return Comment.new COMMENT_FETCH_FAILED

--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -81,20 +81,24 @@ module Github
       notifications
     end
 
+    # コメント取得に失敗した場合に本文へ出す表示用文言。内部エラー文字列を
+    # 通知に晒さず、詳細はログのみに残す（issue #96）。
+    COMMENT_FETCH_FAILED = "（本文を取得できませんでした）"
+
     def find_comment_by_url(url : String) : Comment
       Serverless::Lambda.print_log "comment url: #{url}"
+      # コメントが無い通知（CI 完了など）。本文は付けず title / リンクで対象を示す。
       if url.blank?
-        return Comment.new "no comments exist"
+        return Comment.new nil
       end
 
       res = @github.get url
       if res.status.server_error?
         Serverless::Lambda.print_log "return 5xx error from comments api"
-        return Comment.new "comments api return server error"
+        return Comment.new COMMENT_FETCH_FAILED
       elsif res.status.client_error?
-        Serverless::Lambda.print_log "return 4xx error from comments api"
-        err = Error.from_json res.body
-        return Comment.new "comments api return client error: #{err.message}"
+        Serverless::Lambda.print_log "return 4xx error from comments api: #{res.body}"
+        return Comment.new COMMENT_FETCH_FAILED
       end
 
       begin
@@ -102,7 +106,7 @@ module Github
         Comment.from_json res.body
       rescue
         Serverless::Lambda.print_log "failed parse comment data"
-        Comment.new "failed parse comment data"
+        Comment.new COMMENT_FETCH_FAILED
       end
     end
 

--- a/src/github/usecase.cr
+++ b/src/github/usecase.cr
@@ -4,24 +4,33 @@ require "../notify/models"
 
 module Github
   class Usecase
+    # コメント本文の掲載上限。全文はリンク先で読む前提で、通知が長文で流れるのを
+    # 防ぐため組み立て側（Slack / Discord 共通）で切り詰める（issue #96）。
+    BODY_LIMIT = 500
+
     def initialize(@repo : NotificationRepository)
     end
 
-    def build_message(notify : Notification, pretext : String) : Notify::Message
+    def build_message(notify : Notification) : Notify::Message
       comment = @repo.find_comment_by_url notify.subject.comment_url
       Notify::Message.new(
         mention: notify.mention?,
         author_name: comment.user.login,
         author_icon: comment.user.avatar_url,
         author_link: comment.user.html_url,
-        pretext: pretext,
+        pretext: notify.pretext,
         color: notify.subject.color,
-        title: notify.subject.title,
-        title_link: comment.html_url,
-        text: comment.body,
+        title: notify.display_title,
+        title_link: notify.link(comment),
+        text: truncate_body(comment.body),
         footer: notify.repository.full_name || "github",
         footer_icon: notify.repository.owner.avatar_url,
       )
+    end
+
+    private def truncate_body(body : String?) : String?
+      return nil unless text = body.try(&.presence)
+      text.size > BODY_LIMIT ? "#{text[0, BODY_LIMIT]}…" : text
     end
   end
 end

--- a/src/notify/usecase.cr
+++ b/src/notify/usecase.cr
@@ -20,17 +20,8 @@ module Notify
 
       return {msg: "ok"} if notifications.empty?
 
-      notices = notifications.map do |item|
-        message =
-          if item.subject.update?
-            "更新があったみたいです。確認してみましょう！"
-          else
-            "なにかあったみたいです。確認してみましょう！"
-          end
-        pretext = "[#{item.subject.type}] #{message}"
-
-        @github_uc.build_message item, pretext
-      end
+      # pretext は reason（なぜ通知されたか）を反映した文言になる（issue #96）。
+      notices = notifications.map { |item| @github_uc.build_message item }
 
       # チャンク送信が成功するたび、そこまでに送信済みの通知だけを既読化する。
       # 途中で失敗しても送信済み分は既読化済みなので、未送信分だけが次回


### PR DESCRIPTION
## 概要

issue #96 を解決する。通知の文面・情報量・リンクを見直し、「なぜ通知されたか」「どの対象か」が分かりやすい通知にする。送信先非依存の `Notify::Message` + アダプタ構成は維持し、組み立て側（`Github::Notification` / `Github::Usecase` / `Notify::Usecase`）に変更を集中させた。Slack / Discord アダプタは変更していない。

## 変更内容

### 1. reason ベースの通知文言
`update?` による「更新があったみたいです」一辺倒だと通知理由が伝わらないため、reason（mention / review_requested / assign …）を pretext に反映する。
- `Github::Notification#reason_message` / `#pretext` を追加。`[<type>] <reason 文言>` 形式（例: `[PullRequest] レビューを依頼されました`）
- 未知の reason は汎用文言にフォールバック（GitHub 側の reason 追加に耐える）

### 2. メンション対象の絞り込み → 見送り
issue コメントの「一旦現状を維持する方針」に従い、`MENTION_REASONS` は変更しない。

### 3. title の情報量アップ + リンクのフォールバック
- title を `owner/repo#番号 タイトル` 形式にして対象を一目で分かるようにする（`Notification#display_title`）。番号は `subject.url` 末尾から取得し、数値でない（Commit の SHA 等）場合はタイトルのみ（`Subject#number`）
- title_link をコメント `html_url` → リポジトリ `html_url` にフォールバックし、リンク無し通知を無くす（`Notification#link`）

### 4. 本文の切り詰め + 取得失敗時の表示文言
- コメント本文を `BODY_LIMIT`(500)字 + `…` で切り詰め（全文はリンク先で読む前提）。組み立て側で行い Slack / Discord 共通
- コメント取得失敗時は内部エラー文字列（`comments api return client error: ...`）ではなく「（本文を取得できませんでした）」を本文に出し、エラー詳細はログのみに残す。コメントが無い通知（CI 完了等）は本文を付けない

## 表示イメージ（実ペイロード / Discord）

```
pretext:    [PullRequest] レビューを依頼されました
title:      octocat/Hello-World#128 Fix the thing
title_link: https://github.com/octocat/Hello-World/pull/128#issuecomment-1
text.size:  501   (500字 + …)
```

## テスト

- `spec/github/models_spec.cr`: `reason_message`（既知/未知フォールバック）、`pretext`、`Subject#number`、`display_title`、`link` を追加
- `spec/github/usecase_spec.cr`（新規）: `build_message` の title 形式・リンクフォールバック・本文切り詰め・本文無しを検証
- `crystal spec` 54 examples 0 failures / `ameba` 0 failures / `crystal build src/main.cr` 成功

## 補足

- `Subject#update?` / `UPDATE_TYPES` は本 PR では未使用になるが、モデルの述語として妥当かつ既存 spec もあるため残置した。
- メンション条件（項目2）は方針に従い変更していない。

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)