### PR TITLE
fix: last_read_at の排他的境界により最新通知が既読化されない問題を修正 (#100)

### DIFF
--- a/spec/notify/usecase_spec.cr
+++ b/spec/notify/usecase_spec.cr
@@ -18,16 +18,19 @@ private def t(sec : Int32)
   Time.utc(2026, 1, 1, 0, 0, sec)
 end
 
-# HTTP を張らずに済むよう find_* を差し替え、既読化呼び出しを記録するリポジトリ。
+# HTTP を張らずに済むよう find_* を差し替え、既読化呼び出しと取得スナップ
+# ショット（before）を記録するリポジトリ。
 private class FakeNotificationRepo < Github::NotificationRepository
   getter read_calls = [] of Time?
+  getter before_arg : Time?
 
   # raise_read_after 回目の既読化呼び出しで例外を投げ、既読化失敗を再現する。
   def initialize(@notifications : Array(Github::Notification), @raise_read_after : Int32? = nil)
     super("token")
   end
 
-  def find_notifications_unread : Array(Github::Notification)
+  def find_notifications_unread(before : Time) : Array(Github::Notification)
+    @before_arg = before
     @notifications
   end
 
@@ -66,44 +69,60 @@ private def run(notifications, poster, &)
   repo = FakeNotificationRepo.new notifications
   usecase = Notify::Usecase.new repo, Github::Usecase.new(repo), poster
   yield usecase
-  repo.read_calls
+  repo
 end
 
 describe Notify::Usecase do
   describe "#check_notifications" do
-    it "全チャンク送信成功時は最後に最大 updated_at まで既読化する" do
+    # last_read_at は排他的境界（updated_at < last_read_at のみ既読化、issue #100）
+    # のため、中間チャンクは「未送信先頭の updated_at」、最終チャンクは
+    # 「取得スナップショット」を境界にする。
+
+    it "中間チャンクは未送信先頭の updated_at、最終チャンクは取得スナップショットを境界にする" do
       notifications = [notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:02Z"), notif("2026-01-01T00:00:03Z")]
-      read_calls = run(notifications, ChunkPoster.new([1, 1, 1])) do |usecase|
+      repo = run(notifications, ChunkPoster.new([1, 1, 1])) do |usecase|
         usecase.check_notifications
       end
-      read_calls.should eq [t(1), t(2), t(3)]
+      # 送信済み最新の updated_at (t(3)) を境界にすると排他的比較で t(3) 自身が
+      # 既読化されず毎分再送されるため、最終境界は取得スナップショットまで進める。
+      repo.read_calls.should eq [t(2), t(3), repo.before_arg]
     end
 
     it "途中失敗時は送信済みチャンクまでしか既読化しない" do
       notifications = [notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:02Z"), notif("2026-01-01T00:00:03Z")]
-      read_calls = run(notifications, ChunkPoster.new([1, 1, 1], fail_at: 2)) do |usecase|
+      repo = run(notifications, ChunkPoster.new([1, 1, 1], fail_at: 2)) do |usecase|
         expect_raises(Exception, "send failed") { usecase.check_notifications }
       end
-      # 03 は未送信のまま。既読化は 02 まで（次回に 03 だけ再取得され重複しない）。
-      read_calls.should eq [t(1), t(2)]
+      # t(3) は未送信のまま。境界は t(3)（排他的なので t(3) 自身は既読化されず、
+      # 次回 t(3) だけが再取得され重複しない）。
+      repo.read_calls.should eq [t(2), t(3)]
     end
 
-    it "未送信通知と同一タイムスタンプまで巻き込んで既読化しない" do
-      # 先頭 2 件が同時刻。チャンク境界がその間に落ちても 01 は既読化しない。
+    it "未送信通知と同一タイムスタンプの通知を巻き込んで既読化しない" do
+      # 先頭 2 件が同時刻。チャンク境界がその間に落ちても、境界 t(1) は排他的
+      # なので未送信側の t(1) は既読化されない（送信済み側の t(1) も未読に残り
+      # 次回再送されるが、ロストよりも稀な重複を許容する）。
       notifications = [notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:01Z"), notif("2026-01-01T00:00:02Z")]
-      read_calls = run(notifications, ChunkPoster.new([1, 1, 1])) do |usecase|
+      repo = run(notifications, ChunkPoster.new([1, 1, 1])) do |usecase|
         usecase.check_notifications
       end
-      # 1 チャンク目（01 が 1 件のみ送信済み）の直後は、未送信側にも 01 が
-      # 残るため既読化をスキップ。2 チャンク目以降で安全に前進する。
-      read_calls.should eq [t(1), t(2)]
+      repo.read_calls.should eq [t(1), t(2), repo.before_arg]
+    end
+
+    it "取得時と既読化時で同じスナップショットを使う" do
+      notifications = [notif("2026-01-01T00:00:01Z")]
+      repo = run(notifications, ChunkPoster.new([1])) do |usecase|
+        usecase.check_notifications
+      end
+      repo.before_arg.should_not be_nil
+      repo.read_calls.should eq [repo.before_arg]
     end
 
     it "通知が無ければ既読化しない" do
-      read_calls = run([] of Github::Notification, ChunkPoster.new([] of Int32)) do |usecase|
+      repo = run([] of Github::Notification, ChunkPoster.new([] of Int32)) do |usecase|
         usecase.check_notifications
       end
-      read_calls.should be_empty
+      repo.read_calls.should be_empty
     end
 
     it "既読化に失敗したら後続チャンクの送信を止める" do

--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -26,15 +26,18 @@ module Github
     # 取得してから境界を決める必要がある（issue #94 / PR #97 レビュー指摘）。
     #
     # ページング中に新着通知が入るとオフセットがずれ前ページ末尾の取りこぼしが
-    # 起きるため、取得開始時刻を上限（before）に固定してページ集合を安定させる。
-    # 上限より新しい通知は取得対象から外れるが、次回実行で取得される。
+    # 起きるため、スナップショット時刻を上限（before）に固定してページ集合を
+    # 安定させる。上限より新しい通知は取得対象から外れるが、次回実行で取得される。
+    # before は呼び出し側から受け取る。全件送信後の既読化境界（last_read_at）に
+    # 同じ値を使うことで、取得フィルタ（updated < before）と既読化（updated <
+    # last_read_at）が同じ排他的比較になり、「取得・送信した集合」と「既読化される
+    # 集合」を一致させられる（issue #100）。
     #
     # 取得しきれない場合（途中ページの一時失敗 5xx/401、またはページ数上限到達）は、
     # 不完全な取得状態で既読化して取りこぼすのを避けるため、その実行を丸ごと
     # スキップして次回に委ねる。
-    def find_notifications_unread : Array(Notification)
+    def find_notifications_unread(before : Time) : Array(Notification)
       notifications = [] of Notification
-      before = Time.utc
       complete = false
 
       (1..MAX_PAGES).each do |page|
@@ -119,10 +122,13 @@ module Github
       end
     end
 
-    # 通知を既読化する。last_read_at を渡すと、その時刻以前に更新された通知
-    # だけを既読化する（それ以降に更新された通知は未読のまま残る）。分割送信で
-    # 送信済みチャンクまでを都度既読化し、途中失敗時の重複投稿を防ぐのに使う。
-    # 省略時は現在時刻までの全通知を既読化する。
+    # 通知を既読化する。last_read_at は排他的境界で、その時刻より前
+    # （updated_at < last_read_at）に更新された通知だけが既読化される。
+    # 等値（updated_at == last_read_at）は未読のまま残るため、送信済み通知を
+    # 含めたい場合は境界をその updated_at より大きく取ること（issue #100 で
+    # 実 API 検証済み）。分割送信で送信済みチャンクまでを都度既読化し、
+    # 途中失敗時の重複投稿を防ぐのに使う。省略時は現在時刻までの全通知を
+    # 既読化する。
     def notification_to_read(last_read_at : Time? = nil)
       res =
         if last_read_at

--- a/src/notify/usecase.cr
+++ b/src/notify/usecase.cr
@@ -15,7 +15,10 @@ module Notify
       # 取得スナップショット。取得フィルタ（before）と全件送信後の既読化境界
       # （last_read_at）に同じ値を使うことで、取得・送信した集合と既読化される
       # 集合を一致させる（issue #100）。
-      fetched_at = Time.utc
+      # 秒に切り詰めるのは、両者の一致をシリアライズ精度（現状はどちらも秒単位の
+      # RFC 3339）に依存させないため。サブセカンドの解釈差による取りこぼしを
+      # 構造的に防ぐ。
+      fetched_at = Time.utc.at_beginning_of_second
 
       # updated_at 昇順にソートしてから送信することで、送信済み分を
       # last_read_at で都度既読化できるようにする（issue #94）。

--- a/src/notify/usecase.cr
+++ b/src/notify/usecase.cr
@@ -12,10 +12,15 @@ module Notify
     end
 
     def check_notifications
+      # 取得スナップショット。取得フィルタ（before）と全件送信後の既読化境界
+      # （last_read_at）に同じ値を使うことで、取得・送信した集合と既読化される
+      # 集合を一致させる（issue #100）。
+      fetched_at = Time.utc
+
       # updated_at 昇順にソートしてから送信することで、送信済み分を
       # last_read_at で都度既読化できるようにする（issue #94）。
       notifications = @github_repo
-        .find_notifications_unread
+        .find_notifications_unread(fetched_at)
         .sort_by(&.updated_at)
 
       return {msg: "ok"} if notifications.empty?
@@ -27,37 +32,34 @@ module Notify
       # 途中で失敗しても送信済み分は既読化済みなので、未送信分だけが次回
       # 再取得され、前半チャンクの重複投稿が起きない。
       @poster.send_messages(notices) do |sent_count|
-        mark_read_through notifications, sent_count
+        mark_read_through notifications, sent_count, fetched_at
       end
 
       {msg: "ok"}
     end
 
     # 昇順ソート済み notifications の先頭 sent_count 件（＝送信済み）までを既読化する。
-    # last_read_at は「未送信の先頭通知より前の最大 updated_at」に丸める。これにより
-    # 未送信通知と同一タイムスタンプの通知まで巻き込んで既読化してしまうのを防ぐ
-    # （PUT /notifications は last_read_at 以前に更新された通知を既読化するため）。
-    # 送信済みが全て未送信先頭と同時刻の場合は安全に進められる位置が無いのでスキップし、
-    # 次回実行に委ねる（稀な重複より通知ロストを避ける）。
-    private def mark_read_through(notifications : Array(Github::Notification), sent_count : Int32)
+    #
+    # PUT /notifications の last_read_at は排他的境界で、updated_at < last_read_at
+    # のスレッドだけが既読化される（等値は未読のまま残る。issue #100 で実 API
+    # 検証済み）。これを前提に境界を選ぶ:
+    # - 未送信が残る場合: 境界は未送信先頭の updated_at。排他的なので未送信先頭
+    #   自身は巻き込まれず、それより前に更新された送信済みは全て既読化される。
+    #   同一秒がチャンク境界を跨いだ送信済み分は未読に残り次回再送される
+    #   （稀な重複を許容して通知ロストを避ける）
+    # - 全件送信済みの場合: 境界は取得スナップショット fetched_at。送信済み最新の
+    #   updated_at を境界にすると排他的比較でその通知自身が既読化されず毎分再送
+    #   され続けるため（issue #100 の症状）、取得フィルタと同じ fetched_at まで
+    #   進める。スナップショット以降の新着は未読のまま次回取得される
+    private def mark_read_through(notifications : Array(Github::Notification), sent_count : Int32, fetched_at : Time)
       return if sent_count <= 0
 
       # sent_count は poster 実装（外部境界）から渡るため、通知件数で丸めて
-      # 想定外の値でも安全にスライスできるようにする。
+      # 想定外の値でも安全に扱えるようにする。
       sent_count = {sent_count, notifications.size}.min
-      sent = notifications[0, sent_count]
       next_unsent = notifications[sent_count]?
 
-      last_read_at =
-        if next_unsent.nil?
-          sent.last.updated_at
-        else
-          boundary = next_unsent.updated_at
-          sent.map(&.updated_at).select(&.<(boundary)).max?
-        end
-
-      return if last_read_at.nil?
-
+      last_read_at = next_unsent.try(&.updated_at) || fetched_at
       @github_repo.notification_to_read last_read_at
     end
   end


### PR DESCRIPTION
## 概要

issue #100 を解決する。CI 通知などバッチ内の最新の通知が既読化されず、毎分再送され続ける問題を修正する。

## 原因（実 API 検証済み）

`PUT /notifications` の `last_read_at` は**排他的境界**で、`updated_at < last_read_at` のスレッドだけが既読化される。等値（`updated_at == last_read_at`）は未読のまま残る。

| PUT `last_read_at` | 対象 updated_at | 結果 |
|---|---|---|
| `09:24:54Z`（等値 = 従来実装） | `09:24:54Z` | **unread のまま**（status 205） |
| `09:24:55Z`（+1s） | `09:24:54Z` | 既読化 |

従来の `mark_read_through` は最終チャンクで `last_read_at = sent.last.updated_at`（送信した最新通知自身の時刻）を渡していたため、**バッチ内の最新の1件は原理的に既読化されず**、次回実行で再取得→再送を毎分繰り返していた（新しい通知が届くと境界が追い越して解消するが、今度はその通知がスタックする）。

## 修正内容

排他的境界を前提に境界値を選ぶ:

1. **最終チャンク（全件送信済み）**: 境界を取得スナップショット `fetched_at` にする
   - 取得フィルタ（`before` = updated < fetched_at）と同じ値・同じ排他的比較のため、**「取得・送信した集合」と「既読化される集合」が正確に一致**する
   - スナップショット以降の新着は既読化されず次回取得される（取りこぼしの窓も従来より狭い）
   - `find_notifications_unread` がスナップショットを引数で受け取るよう変更し、`Notify::Usecase` が取得と既読化で同じ値を使う
2. **中間チャンク（未送信が残る）**: 境界を未送信先頭の `updated_at` にする
   - 排他的なので未送信先頭自身は巻き込まれない
   - 従来の「境界未満の最大 updated_at」は等値の送信済み通知を取り残す同種の問題があったが、これも同時に解消（従来より広くカバー）
   - 同一秒がチャンク境界を跨いだ送信済み分は未読に残り次回再送される（稀な重複を許容して通知ロストを避ける。従来と同じトレードオフ）

## 途中失敗時の保証（従来どおり）

- 送信済みチャンクまでは既読化済み、未送信分だけが次回再取得 → 重複投稿なし
- 境界は常に控えめ（排他的）に倒れるため通知ロストは起きない

## テスト

- `spec/notify/usecase_spec.cr` を新しい境界選択に合わせて更新
  - 中間チャンク境界 = 未送信先頭の updated_at / 最終チャンク境界 = 取得スナップショット
  - 取得時と既読化時で同じスナップショットを使うことの検証を追加
  - 途中失敗・同一タイムスタンプ・既読化失敗時の送信停止は従来の保証を維持
- `crystal spec` 59 examples 0 failures / `ameba` 0 failures / `crystal build src/main.cr` 成功

## 動作確認方法

マージ後 dev にデプロイし、次の CI 通知（CheckSuite）が 1 回だけ送信されて既読化されること（再送が続かないこと）を確認する。

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)