### PR TITLE
fix: GitHub への接続を実行ごとに張り直す (#102)

### DIFF
--- a/src/github/repository.cr
+++ b/src/github/repository.cr
@@ -37,6 +37,16 @@ module Github
     # 不完全な取得状態で既読化して取りこぼすのを避けるため、その実行を丸ごと
     # スキップして次回に委ねる。
     def find_notifications_unread(before : Time) : Array(Notification)
+      # ウォームスタート間で使い回した keep-alive 接続が GitHub 側の古い
+      # レプリカに固定され、未読があるのに空応答が約47分続く事象を観測した
+      # （issue #102）。実行のたびに接続を張り直して固定を解き、古い応答を
+      # 読み続ける時間を最長でも1実行間隔（1分）に抑える。同一実行内の
+      # ページング・コメント取得・既読化ではそのまま再利用される
+      # （close 後の接続は次のリクエストで自動的に張り直される）。
+      # TLS ハンドシェイクが毎実行1回増えるが、毎分・数百 ms の処理なので
+      # 通知が長時間届かないリスクより軽いと判断した。
+      @github.close
+
       notifications = [] of Notification
       complete = false
 

--- a/src/main.cr
+++ b/src/main.cr
@@ -30,6 +30,9 @@ end
 
 # 依存はコールドスタート時に一度だけ生成し、ウォームスタート間で使い回すことで
 # HTTP::Client のコネクション（TCP/SSL）を再利用する。
+# ただし GitHub への接続は、古いレプリカへの固定で未読通知が長時間取得できなく
+# なる事象があったため、実行ごとに張り直す（issue #102 /
+# Github::NotificationRepository#find_notifications_unread 参照）。
 github_repo = Github::NotificationRepository.new GITHUB_TOKEN
 notify_uc = Notify::Usecase.new(
   github_repo,


### PR DESCRIPTION
## 概要

issue #102 を解決する。ウォーム Lambda が使い回す keep-alive 接続が GitHub 側の古いレプリカに固定され、未読通知があるのに `GET /notifications` が空応答を返し続ける（観測時は約47分間）事象への対策。

## 事象の整理（issue #102）

- dev Lambda の `GET /notifications` が 09:41〜10:27 の約47分間、毎分 200 で `[]` を返し続けた（未読1件が存在するのに）
- 同時刻・同一トークン・同一 URL の curl / ローカルの同一 Crystal コードでは正常に取得できた
- 再デプロイ（コールドスタート＝新規 TLS 接続）直後の実行で即座に取得できた

→ コールドスタート時に生成し使い回している `HTTP::Client` の長寿命接続が、GitHub 側 LB により古いレプリカへ固定されたと推定。発生中は新着通知が一切届かず、エラーも出ないため気づけない。

## 対応（issue の案1の強化版: 実行ごとに張り直し）

取得の起点 `find_notifications_unread` の冒頭で `@github.close` を呼び、実行のたびに接続を張り直す。

- **古い応答を読み続ける時間が最長でも1実行間隔（1分）に抑えられる**
- `close` 後の接続は次のリクエストで自動的に張り直される（未接続時の `close` も安全。実挙動確認済み）
- 同一実行内のページング・コメント取得（N件）・既読化では従来どおり接続を再利用するため、N+1 側の性能は変わらない
- 犠牲になるのは実行あたり TLS ハンドシェイク1回（数百 ms 未満）。毎分・実行時間数百 ms のワークロードでは、通知が長時間届かないリスクより明確に軽い

### 他案との比較

- 案1（TTL 5〜10分で再生成）: ステイルネス窓が TTL 分残る。ハンドシェイク削減の利益が毎分実行では微小なため、窓を最小化できる毎実行張り直しを採用
- 案2（`Connection: close`）: リクエスト単位で接続が切れ、同一実行内の N 回のコメント取得まで手数が増える
- 案3（連続空応答で張り直し）: 状態管理が増えるうえ、正常に空の期間と区別できず復旧が N 分遅れる

## テスト・検証

- `crystal spec` 59 examples 0 failures / `ameba` 0 failures / `crystal build src/main.cr` 成功
- `close` → リクエストの自動再接続をローカルで実挙動確認（未接続時 close / 接続済み close の両方）
- 事象自体はオンデマンド再現が不可能なため、マージ後は再発監視（dev/prod のログで長時間の空応答が出ないこと）で確認する

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)